### PR TITLE
docs: main·dev 브랜치 보호 규칙 적용 (F-66)

### DIFF
--- a/docs/features/feature-status.md
+++ b/docs/features/feature-status.md
@@ -50,6 +50,7 @@
 | F-52 | Cloudflare Workers 배포 (dev/prod) | `wrangler.jsonc`, `ci.yml` deploy 잡 | **실배포 성공** (dev·prod) |
 | F-63 | prod 커스텀 도메인 `md-editor.devworld.co.kr` | `wrangler.jsonc` `routes` | **실서비스 중** + prod E2E 58건 |
 | F-53 | 저장소 사용 불가 환경 안내 | `main.ts`, `storage.ts` | 단위 |
+| F-66 | `main`·`dev` 브랜치 보호 규칙 | GitHub branch protection | 직접 push 거부 확인 |
 
 ## 3. 부분 구현 (⚠️)
 
@@ -124,7 +125,6 @@
 | F-45 | 린터 / 포매터 (ESLint·Prettier) | 설정 없음 |
 | F-47 | 단위 테스트 커버리지 | 8.11% — [커버리지 분석](../testing/coverage.md) |
 | F-65 | 크로스 브라우저 E2E (Firefox·WebKit 프로젝트) | Chromium 만 실행 |
-| F-66 | 브랜치 보호 규칙 | `dev` 브랜치는 생성·운영 중. **보호 규칙(PR 필수·상태 체크 필수)은 미설정** |
 
 ## 5. 제거됨 (🗑)
 
@@ -145,8 +145,7 @@
 
 ```mermaid
 graph TD
-  A["1. F-66 브랜치 보호 규칙<br/>(PR 필수·상태 체크 필수)"] --> B["2. F-62 CSP 헤더"]
-  B --> C["3. F-54 저장소 용량 초과 알림"]
+  B["1. F-62 CSP 헤더"] --> C["2. F-54 저장소 용량 초과 알림"]
   C --> D["4. F-61 PWA<br/>(오프라인·설치형)"]
   D --> E["5. F-47 단위 커버리지 60%+"]
   E --> F["6. F-57 다크모드 / F-25 스크롤 동기화<br/>F-58 단축키 안내"]
@@ -156,9 +155,8 @@ graph TD
 
 ### 즉시 조치 권장
 
-1. **F-66** — 보호 규칙이 없으면 `main` 에 직접 push 가 가능해 릴리즈 절차를 우회할 수 있다.
-2. **F-62** — 공개 URL 로 배포되는 이상 CSP 는 DOMPurify 다음의 두 번째 방어선이다.
-3. **F-54** — 자동 저장 실패를 사용자가 모른다면 자동 저장이 오히려 잘못된 안심을 준다.
+1. **F-62** — 공개 URL 로 배포되는 이상 CSP 는 DOMPurify 다음의 두 번째 방어선이다.
+2. **F-54** — 자동 저장 실패를 사용자가 모른다면 자동 저장이 오히려 잘못된 안심을 준다.
 
 ## 7. 관련 문서
 

--- a/docs/operations/branch-strategy.md
+++ b/docs/operations/branch-strategy.md
@@ -25,10 +25,12 @@ push 시 배포는 `.github/workflows/deploy.yml` 이 자동 수행한다. 상�
 |------|-----|
 | 존재하는 브랜치 | `main` 만 |
 | `dev` 브랜치 | **미생성** |
-| 브랜치 보호 규칙 | 미설정 |
-| CI/CD 워크플로 | 추가됨 (`ci.yml`, `deploy.yml`) — **`dev` 가 없어 아직 미실행** |
+| 존재하는 브랜치 | `main`, `dev` |
+| 브랜치 보호 규칙 | ✅ `main`·`dev` 모두 적용 (§6) |
+| CI/CD 워크플로 | ✅ `ci.yml` (`verify` → `deploy`) 운영 중 |
+| 릴리즈 이력 | PR #1 (v2.0.0 웹 전환), PR #2 (릴리즈 기록·스택 프로필) |
 
-→ 전략 적용을 위해 `dev` 브랜치 생성과 보호 규칙 설정이 선행돼야 한다 (§6). 이것이 [F-66](../features/feature-status.md) 이며 현재 최우선 조치 항목이다.
+전략이 실제로 강제되고 있다. `main`·`dev` 모두 직접 push 가 거부된다.
 
 ## 3. 명명 규칙
 
@@ -75,6 +77,9 @@ gitGraph
   merge dev tag: "v2.1.0 릴리즈"
 ```
 
+> **보호 규칙 적용 후에는 `dev` 에도 직접 push 할 수 없다.** 문서 한 줄 수정이라도
+> `feature/*` 브랜치 → PR → 머지 경로를 거쳐야 한다.
+
 ### 5.1 기능 개발 절차
 
 1. `dev` 최신화 후 `feature/<요약>` 분기
@@ -105,15 +110,43 @@ gitGraph
 
 `main` 에서 `hotfix/*` 분기 → 수정 → `main` 병합 + 태그 → **`dev` 에도 반드시 병합**(누락 시 다음 릴리즈에서 회귀).
 
-## 6. 적용 준비 작업 (미완료)
+## 6. 브랜치 보호 규칙 (적용 완료)
 
-- [ ] `dev` 브랜치 생성 (`git checkout -b dev main && git push -u origin dev`)
+`main` 과 `dev` 에 동일 규칙을 적용했다 (2026-08-12).
+
+| 항목 | 값 | 의미 |
+|------|-----|------|
+| PR 필수 | ✅ | 직접 push 거부 (`GH006: Protected branch update failed`) |
+| 필요 승인 수 | **0** | 메인테이너가 1명이라 1 이상이면 자기 PR 을 승인할 수 없어 머지가 영구 차단된다 |
+| 필수 상태 체크 | `verify` | 빌드 + 단위 + E2E. **`deploy` 는 넣지 않는다** — PR 에서 skip 되므로 필수로 걸면 영구 대기 상태가 된다 |
+| strict (최신화 강제) | `false` | 머지 커밋 때문에 `dev` 가 항상 `main` 보다 뒤처져 매번 동기화가 필요해진다. PR 체크는 이미 base+head 병합 결과에서 돌므로 실익이 적다 |
+| 관리자에도 적용 | ✅ | 소유자도 우회 불가 |
+| 강제 push | ❌ 금지 | 히스토리 훼손 방지 |
+| 브랜치 삭제 | ❌ 금지 | `dev`/`main` 실수 삭제 방지 |
+
+### 적용 명령
+
+```bash
+gh api -X PUT repos/OWNER/REPO/branches/main/protection --input protection.json
+gh api -X PUT repos/OWNER/REPO/branches/dev/protection  --input protection.json
+```
+
+### 긴급 상황 우회
+
+관리자에도 적용되므로 우회하려면 규칙을 **일시 해제**해야 한다.
+
+```bash
+gh api -X DELETE repos/OWNER/REPO/branches/main/protection   # 해제
+# 조치 후 위 PUT 으로 재적용
+```
+
+### 남은 준비 작업
+
 - [ ] 기본 브랜치를 `dev` 로 변경 (PR 기본 타깃)
-- [ ] `main`·`dev` 브랜치 보호 규칙 설정 (PR 필수, 상태 체크 필수)
-- [x] CI 워크플로 추가 (`ci.yml`) — **필수 상태 체크 등록은 미완료**
-- [x] CD 워크플로 추가 (`deploy.yml`)
-- [ ] `CLOUDFLARE_API_TOKEN` · `CLOUDFLARE_ACCOUNT_ID` 시크릿 등록
-- [x] `MarkdownEditor.dmg` 를 Git 추적에서 제거 (웹 전환 시 삭제)
+- [ ] 승인 1명 필수로 상향 (협업자가 2명 이상 활동할 때)
+- [x] CI/CD 워크플로 (`ci.yml`: `verify` → `deploy`)
+- [x] `CLOUDFLARE_API_TOKEN` · `CLOUDFLARE_ACCOUNT_ID` 시크릿 등록
+- [x] `MarkdownEditor.dmg` 를 Git 추적에서 제거
 
 ## 7. 문서 동기화 규칙
 

--- a/docs/testing/test-results.md
+++ b/docs/testing/test-results.md
@@ -118,7 +118,6 @@ E2E 를 새로 작성하는 과정에서 **실제 결함 3건**이 드러났다.
 | 중간 | localStorage 저장 실패(용량 초과)를 사용자에게 알리지 않는다 | [F-54](../features/feature-status.md) |
 | 중간 | 폴백 브라우저에서 덮어쓰기·중복 탭 방지 불가 (API 한계, 안내 UI 없음) | [F-11, F-58](../features/feature-status.md) |
 | 낮음 | CSP 헤더 미설정 | [F-62](../features/feature-status.md) |
-| 낮음 | 브랜치 보호 규칙 미설정 (`main` 직접 push 가능) | [F-66](../features/feature-status.md) |
 
 ## 6.5 배포 환경 검증 (2026-08-12)
 


### PR DESCRIPTION
`main`·`dev` 에 GitHub branch protection 을 적용하고 문서에 반영한다. 문서 변경만 포함하며 애플리케이션 코드 변경은 없다.

## 적용한 규칙 (main·dev 동일)

| 항목 | 값 | 비고 |
|------|-----|------|
| PR 필수 | ✅ | 직접 push 거부 |
| 필요 승인 수 | **0** | 아래 사유 참조 |
| 필수 상태 체크 | `verify` | `deploy` 는 제외 |
| strict (최신화 강제) | `false` | 아래 사유 참조 |
| 관리자에도 적용 | ✅ | 소유자도 우회 불가 |
| 강제 push · 브랜치 삭제 | ❌ 금지 | |

## 설정 근거 (함정 3가지를 피한 선택)

1. **승인 수를 0 으로** — 활동 메인테이너가 1명이다. 1 이상으로 두면 자기 PR 을 승인할 수 없어 **머지가 영구 차단**된다. 협업자가 늘면 상향한다.
2. **`deploy` 를 필수 체크에서 제외** — `deploy` 잡은 `if: github.event_name == 'push'` 라 PR 에서 skip 된다. 필수로 걸면 체크가 영원히 완료되지 않아 역시 머지가 막힌다.
3. **`strict=false`** — 머지 커밋 때문에 `dev` 는 항상 `main` 보다 1~2 커밋 뒤처진다(현재 2커밋). `strict=true` 면 릴리즈마다 `dev` 를 `main` 으로 동기화해야 한다. PR 체크는 이미 base+head 병합 결과에서 돌기 때문에 실익이 적다.

## 검증

`dev` 에 빈 커밋을 직접 push 해 실제로 막히는지 확인했다.

```
remote: error: GH006: Protected branch update failed for refs/heads/dev.
remote: - Changes must be made through a pull request.
remote: - Required status check "verify" is expected.
 ! [remote rejected] dev -> dev (protected branch hook declined)
```

## 워크플로 변화

**이제 `dev` 에도 직접 push 할 수 없다.** 문서 한 줄 수정이라도 `feature/*` → PR → 머지 경로를 거쳐야 한다. 이 PR 자체가 그 경로를 처음 통과하는 사례다.

긴급 시 우회는 규칙 일시 해제로만 가능하며, 절차를 `docs/operations/branch-strategy.md` §6 에 적어뒀다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CtFxzJ9wgUjid5dDvZBNm