### PR TITLE
fix: CSP 가 Cloudflare Web Analytics 비콘을 차단하던 문제 (F-62)

### DIFF
--- a/docs/api/browser-apis.md
+++ b/docs/api/browser-apis.md
@@ -270,7 +270,7 @@ sequenceDiagram
 | 경로 노출 | ✅ 브라우저가 절대 경로를 숨긴다 |
 | 문서 유출 | ✅ 문서가 네트워크로 전송되지 않는다 |
 | localStorage 격리 | ⚠️ 같은 오리진의 다른 스크립트가 세션을 읽을 수 있다. 공유 호스팅 오리진에 배포하지 말 것 |
-| CSP | ✅ `public/_headers` — `script-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`. [인프라 §6.1](../architecture/infrastructure.md#61-보안-헤더-public_headers) |
+| CSP | ✅ `public/_headers` — `script-src 'self' + CF Insights 비콘`, `object-src 'none'`, `frame-ancestors 'none'`. [인프라 §6.1](../architecture/infrastructure.md#61-보안-헤더-public_headers) |
 
 ---
 

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -167,7 +167,7 @@ CI 와 CD 는 `.github/workflows/ci.yml` 한 파일의 **두 잡**이다. `deplo
 
 | 헤더 | 값 |
 |------|-----|
-| `Content-Security-Policy` | `default-src 'self'; script-src 'self'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests` |
+| `Content-Security-Policy` | `default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://cloudflareinsights.com; manifest-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests` |
 | `X-Content-Type-Options` | `nosniff` |
 | `Referrer-Policy` | `no-referrer` |
 | `X-Frame-Options` | `DENY` |
@@ -181,8 +181,10 @@ CI 와 CD 는 `.github/workflows/ci.yml` 한 파일의 **두 잡**이다. `deplo
 | `style-src` | `'unsafe-inline'` 허용 | 마크다운 본문의 인라인 `style` 속성(DOMPurify 가 허용)이 렌더되려면 필요. 인라인 스크립트와 달리 실행 권한이 없어 위험도가 낮다 |
 | `img-src` | `https:` 허용 | 문서의 `![](https://…)` 외부 이미지 |
 | `img-src` | `data:` 허용 | 인라인 SVG·data URI 이미지 |
+| `script-src` | `https://static.cloudflareinsights.com` 허용 | Cloudflare Web Analytics 가 **커스텀 도메인에만** 비콘을 엣지 주입한다. `*.workers.dev`(dev)에는 주입되지 않아 dev 검증에서 드러나지 않았고, prod E2E 에서 처음 잡혔다. 차단하면 모든 사용자 콘솔에 CSP 위반 에러가 남는다 |
+| `connect-src` | `https://cloudflareinsights.com` 허용 | 위 비콘의 전송 대상 |
 
-`script-src` 는 `'self'` 만 허용하며 `'unsafe-inline'`·`'unsafe-eval'` 을 절대 넣지 않는다. E2E 가 이를 단언한다.
+`script-src` 는 `'self'` + Cloudflare Insights 비콘 호스트만 허용하며 `'unsafe-inline'`·`'unsafe-eval'` 은 절대 넣지 않는다. E2E 가 허용 호스트 목록을 **정확히 일치**로 단언하므로, 외부 스크립트를 추가하려면 테스트도 함께 고쳐야 한다.
 
 **캐시 규칙**
 

--- a/public/_headers
+++ b/public/_headers
@@ -11,7 +11,12 @@
   # 실행 권한이 없어 위험도가 낮다.
   # img-src 에 https: 가 필요한 이유: 문서의 ![](https://…) 외부 이미지.
   # img-src 에 data: 가 필요한 이유: 인라인 SVG 파비콘.
-  Content-Security-Policy: default-src 'self'; script-src 'self'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests
+  #
+  # cloudflareinsights.com 을 허용하는 이유: Cloudflare Web Analytics 가 커스텀
+  # 도메인(prod)에 비콘 스크립트를 엣지에서 자동 주입한다. *.workers.dev(dev)에는
+  # 주입되지 않아 dev 에서는 드러나지 않았다. 차단하면 모든 사용자 콘솔에 CSP 위반
+  # 에러가 남는다. 특정 호스트만 허용하므로 'unsafe-inline' 같은 광범위 완화는 아니다.
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://cloudflareinsights.com; manifest-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer
   X-Frame-Options: DENY

--- a/tests/e2e/hardening.spec.ts
+++ b/tests/e2e/hardening.spec.ts
@@ -116,8 +116,18 @@ test.describe("F-62 보안 헤더", () => {
     expect(csp).toContain("script-src 'self'");
     expect(csp).toContain("object-src 'none'");
     expect(csp).toContain("frame-ancestors 'none'");
-    // 인라인 스크립트는 절대 허용하지 않는다.
-    expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
+    // 인라인 스크립트·eval 은 어떤 경우에도 허용하지 않는다.
+    expect(csp).not.toContain("'unsafe-inline'; script-src");
+    expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+    expect(csp).not.toContain("'unsafe-eval'");
+    // 외부 스크립트는 Cloudflare Web Analytics 비콘만 허용한다.
+    const scriptSrc = csp.split(";").find((d) => d.trim().startsWith("script-src"))!;
+    const allowedHosts = scriptSrc
+      .replace("script-src", "")
+      .trim()
+      .split(/\s+/)
+      .filter((t) => t !== "'self'");
+    expect(allowedHosts).toEqual(["https://static.cloudflareinsights.com"]);
 
     expect(headers["x-content-type-options"]).toBe("nosniff");
     expect(headers["referrer-policy"]).toBe("no-referrer");


### PR DESCRIPTION
## 증상

prod 배포 후 E2E 를 돌리자 "CSP 위반 없이 페이지가 동작한다" 케이스가 실패했다.

```
Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/...'
violates the following Content Security Policy directive: "script-src 'self'".
The action has been blocked.
```

## 왜 dev 에서 못 잡았나

Cloudflare Web Analytics 는 **커스텀 도메인에만** 비콘을 엣지에서 자동 주입한다. `*.workers.dev`(dev)에는 주입되지 않아 dev 환경 E2E 는 9/9 통과했고, prod 배포 후에야 드러났다.

HTML 원본에는 이 스크립트가 없다(curl 로는 안 보인다). 브라우저 요청에만 엣지에서 삽입되므로 **실제 브라우저로 검증해야만** 잡히는 종류의 문제다.

## 영향

보안 취약점은 아니다(차단이 동작한 것). 다만 **모든 사용자 콘솔에 CSP 위반 에러가 남고** 분석이 수집되지 않는다.

## 수정

```diff
- script-src 'self';
+ script-src 'self' https://static.cloudflareinsights.com;
- connect-src 'self';
+ connect-src 'self' https://cloudflareinsights.com;
```

특정 호스트만 허용하므로 `'unsafe-inline'`/`'unsafe-eval'` 같은 광범위 완화가 아니다.

**대안 검토**: 존 수준에서 Web Analytics 를 끄는 방법도 있으나, 설정이 `devworld.co.kr` **존 전체**에 영향을 줄 수 있어 이 앱만의 결정으로 삼기 어렵다고 판단했다.

## 테스트 강화

단언을 느슨한 문자열 포함에서 **허용 호스트 목록 정확 일치**로 바꿨다.

```ts
const allowedHosts = scriptSrc.replace("script-src", "").trim().split(/\s+/)
  .filter((t) => t !== "'self'");
expect(allowedHosts).toEqual(["https://static.cloudflareinsights.com"]);
expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
expect(csp).not.toContain("'unsafe-eval'");
```

이제 외부 스크립트를 하나라도 더 넣으면 테스트가 실패한다 — CSP 가 조용히 느슨해지는 것을 막는다.

## 검증

`tsc` 0 오류 / 빌드 성공 / 로컬 E2E 78 통과 + 4 skip. 병합 후 dev → prod 순으로 실제 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CtFxzJ9wgUjid5dDvZBNm