### PR TITLE
release: CSP Cloudflare Insights 비콘 허용 (F-62 후속)

### DIFF
--- a/docs/api/browser-apis.md
+++ b/docs/api/browser-apis.md
@@ -270,7 +270,7 @@ sequenceDiagram
 | 경로 노출 | ✅ 브라우저가 절대 경로를 숨긴다 |
 | 문서 유출 | ✅ 문서가 네트워크로 전송되지 않는다 |
 | localStorage 격리 | ⚠️ 같은 오리진의 다른 스크립트가 세션을 읽을 수 있다. 공유 호스팅 오리진에 배포하지 말 것 |
-| CSP | ✅ `public/_headers` — `script-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`. [인프라 §6.1](../architecture/infrastructure.md#61-보안-헤더-public_headers) |
+| CSP | ✅ `public/_headers` — `script-src 'self' + CF Insights 비콘`, `object-src 'none'`, `frame-ancestors 'none'`. [인프라 §6.1](../architecture/infrastructure.md#61-보안-헤더-public_headers) |
 
 ---
 

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -167,7 +167,7 @@ CI 와 CD 는 `.github/workflows/ci.yml` 한 파일의 **두 잡**이다. `deplo
 
 | 헤더 | 값 |
 |------|-----|
-| `Content-Security-Policy` | `default-src 'self'; script-src 'self'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests` |
+| `Content-Security-Policy` | `default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://cloudflareinsights.com; manifest-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests` |
 | `X-Content-Type-Options` | `nosniff` |
 | `Referrer-Policy` | `no-referrer` |
 | `X-Frame-Options` | `DENY` |
@@ -181,8 +181,10 @@ CI 와 CD 는 `.github/workflows/ci.yml` 한 파일의 **두 잡**이다. `deplo
 | `style-src` | `'unsafe-inline'` 허용 | 마크다운 본문의 인라인 `style` 속성(DOMPurify 가 허용)이 렌더되려면 필요. 인라인 스크립트와 달리 실행 권한이 없어 위험도가 낮다 |
 | `img-src` | `https:` 허용 | 문서의 `![](https://…)` 외부 이미지 |
 | `img-src` | `data:` 허용 | 인라인 SVG·data URI 이미지 |
+| `script-src` | `https://static.cloudflareinsights.com` 허용 | Cloudflare Web Analytics 가 **커스텀 도메인에만** 비콘을 엣지 주입한다. `*.workers.dev`(dev)에는 주입되지 않아 dev 검증에서 드러나지 않았고, prod E2E 에서 처음 잡혔다. 차단하면 모든 사용자 콘솔에 CSP 위반 에러가 남는다 |
+| `connect-src` | `https://cloudflareinsights.com` 허용 | 위 비콘의 전송 대상 |
 
-`script-src` 는 `'self'` 만 허용하며 `'unsafe-inline'`·`'unsafe-eval'` 을 절대 넣지 않는다. E2E 가 이를 단언한다.
+`script-src` 는 `'self'` + Cloudflare Insights 비콘 호스트만 허용하며 `'unsafe-inline'`·`'unsafe-eval'` 은 절대 넣지 않는다. E2E 가 허용 호스트 목록을 **정확히 일치**로 단언하므로, 외부 스크립트를 추가하려면 테스트도 함께 고쳐야 한다.
 
 **캐시 규칙**
 

--- a/public/_headers
+++ b/public/_headers
@@ -11,7 +11,12 @@
   # 실행 권한이 없어 위험도가 낮다.
   # img-src 에 https: 가 필요한 이유: 문서의 ![](https://…) 외부 이미지.
   # img-src 에 data: 가 필요한 이유: 인라인 SVG 파비콘.
-  Content-Security-Policy: default-src 'self'; script-src 'self'; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; manifest-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests
+  #
+  # cloudflareinsights.com 을 허용하는 이유: Cloudflare Web Analytics 가 커스텀
+  # 도메인(prod)에 비콘 스크립트를 엣지에서 자동 주입한다. *.workers.dev(dev)에는
+  # 주입되지 않아 dev 에서는 드러나지 않았다. 차단하면 모든 사용자 콘솔에 CSP 위반
+  # 에러가 남는다. 특정 호스트만 허용하므로 'unsafe-inline' 같은 광범위 완화는 아니다.
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; worker-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://cloudflareinsights.com; manifest-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer
   X-Frame-Options: DENY

--- a/tests/e2e/hardening.spec.ts
+++ b/tests/e2e/hardening.spec.ts
@@ -116,8 +116,18 @@ test.describe("F-62 보안 헤더", () => {
     expect(csp).toContain("script-src 'self'");
     expect(csp).toContain("object-src 'none'");
     expect(csp).toContain("frame-ancestors 'none'");
-    // 인라인 스크립트는 절대 허용하지 않는다.
-    expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
+    // 인라인 스크립트·eval 은 어떤 경우에도 허용하지 않는다.
+    expect(csp).not.toContain("'unsafe-inline'; script-src");
+    expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+    expect(csp).not.toContain("'unsafe-eval'");
+    // 외부 스크립트는 Cloudflare Web Analytics 비콘만 허용한다.
+    const scriptSrc = csp.split(";").find((d) => d.trim().startsWith("script-src"))!;
+    const allowedHosts = scriptSrc
+      .replace("script-src", "")
+      .trim()
+      .split(/\s+/)
+      .filter((t) => t !== "'self'");
+    expect(allowedHosts).toEqual(["https://static.cloudflareinsights.com"]);
 
     expect(headers["x-content-type-options"]).toBe("nosniff");
     expect(headers["referrer-policy"]).toBe("no-referrer");


### PR DESCRIPTION
직전 릴리즈(PR #5)로 prod 에 CSP 를 적용한 직후, prod E2E 에서 발견한 문제를 고친다.

## 문제

Cloudflare Web Analytics 가 **커스텀 도메인에만** 비콘 스크립트를 엣지에서 자동 주입하는데 `script-src 'self'` 가 이를 차단했다.

```
Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/...'
violates the following Content Security Policy directive: "script-src 'self'".
```

보안 취약점은 아니지만(차단이 정상 동작한 것), 모든 사용자 콘솔에 CSP 위반 에러가 남고 분석이 수집되지 않는다.

`*.workers.dev`(dev)에는 주입되지 않아 dev 검증 9/9 통과에서는 드러나지 않았다. **커스텀 도메인 전용 동작**이라는 점이 이 문제의 핵심이다.

## 수정

`script-src` 에 `https://static.cloudflareinsights.com`, `connect-src` 에 `https://cloudflareinsights.com` 을 추가했다. 특정 호스트만 허용하므로 `'unsafe-inline'`/`'unsafe-eval'` 같은 광범위 완화가 아니다.

E2E 단언도 강화했다 — `script-src` 허용 호스트를 **정확 일치**로 검사하므로 외부 스크립트가 하나라도 늘면 테스트가 실패한다.

## 검증

dev 배포 후 확인 완료. `verify`·`deploy` 모두 success.

병합 후 prod 에서 CSP 위반 0건을 재확인할 예정이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CtFxzJ9wgUjid5dDvZBNm