### PR TITLE
refactor: PR #9 리뷰 P2 4건 정리 (swUpdate.ts)

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,10 @@
           hidden
         >
           <p id="sw-update-text" class="sw-update-text">
-            새 버전이 준비됐습니다.<br />새로고침하면 최신 버전으로 전환됩니다.
+            <span id="sw-update-text-idle"
+              >새 버전이 준비됐습니다.<br />새로고침하면 최신 버전으로 전환됩니다.</span
+            >
+            <span id="sw-update-text-updating" hidden>새 버전으로 전환하는 중입니다...</span>
           </p>
           <div class="sw-update-actions">
             <button type="button" id="sw-update-later" class="sw-update-btn">나중에</button>

--- a/src/swUpdate.ts
+++ b/src/swUpdate.ts
@@ -16,6 +16,9 @@ export interface SwUpdateHost {
   register(): Promise<ServiceWorkerRegistration | null>;
   /** controllerchange 구독. 해제 함수를 반환 */
   onControllerChange(fn: () => void): () => void;
+  /** 이 페이지를 제어 중인 서비스 워커 존재 여부(표시 판정용). 기본 구현은
+   * navigator.serviceWorker?.controller 존재 여부. */
+  hasController(): boolean;
   /** 세션 확정 저장. 성공 여부를 반환 (= tabs.persistNow) */
   persist(): boolean;
   /** 미저장 탭 존재 여부 (= tabs.hasDirtyTabs) */
@@ -47,6 +50,15 @@ type PanelState = "idle" | "updating";
 /** main.ts 의 beforeunload 가 이탈 경고 억제 여부를 판단할 때 읽는다 (U5). */
 let reloadPending = false;
 
+/**
+ * 재진입 가드(U5 와 동일한 모듈 스코프 상태). main.ts 는 initSwUpdate 를 앱 생애주기당
+ * 정확히 한 번만 호출하므로 실질적 위험은 없지만, 두 번째 호출이 setInterval 을
+ * 중복 등록해 첫 등록을 정리할 방법이 없는 상태로 남기는 것을 막는다. 이 모듈에는
+ * 별도의 dispose 훅을 거는 호출자가 없으므로 정리 함수를 반환하는 방식은 아무도
+ * 쓰지 않는 코드가 되어 가드 쪽이 이 코드베이스에 맞다.
+ */
+let initialized = false;
+
 export function isUpdateReloadPending(): boolean {
   return reloadPending;
 }
@@ -63,6 +75,7 @@ function resolveHost(
       navigator.serviceWorker.addEventListener("controllerchange", fn);
       return () => navigator.serviceWorker.removeEventListener("controllerchange", fn);
     },
+    hasController: () => Boolean(navigator.serviceWorker?.controller),
     persist: () => false,
     hasDirty: () => false,
     confirmUnsafeReload: (message) => window.confirm(message),
@@ -81,11 +94,17 @@ function resolveHost(
 export function initSwUpdate(
   partialHost: Partial<SwUpdateHost> & Pick<SwUpdateHost, "panelEl">,
 ): void {
+  if (initialized) {
+    console.warn("[sw-update] 이미 초기화되어 재호출을 무시합니다.");
+    return;
+  }
+  initialized = true;
   try {
     const host = resolveHost(partialHost);
     const panelEl = host.panelEl;
 
-    const textEl = panelEl.querySelector<HTMLElement>("#sw-update-text");
+    const textIdleEl = panelEl.querySelector<HTMLElement>("#sw-update-text-idle");
+    const textUpdatingEl = panelEl.querySelector<HTMLElement>("#sw-update-text-updating");
     const laterBtn = panelEl.querySelector<HTMLButtonElement>("#sw-update-later");
     const reloadBtn = panelEl.querySelector<HTMLButtonElement>("#sw-update-reload");
 
@@ -104,17 +123,16 @@ export function initSwUpdate(
       const updating = state === "updating";
       if (laterBtn) laterBtn.disabled = updating;
       if (reloadBtn) reloadBtn.disabled = updating;
-      if (textEl) {
-        textEl.innerHTML = updating
-          ? "새 버전으로 전환하는 중입니다..."
-          : "새 버전이 준비됐습니다.<br />새로고침하면 최신 버전으로 전환됩니다.";
-      }
+      // 정적 문구는 index.html 에 두 요소로 미리 존재하며 여기서는 hidden 만 토글한다
+      // (parseMarkdown() 을 우회하는 innerHTML 대입을 피한다).
+      if (textIdleEl) textIdleEl.hidden = updating;
+      if (textUpdatingEl) textUpdatingEl.hidden = !updating;
     }
 
     function show(): void {
       // 최초 설치(제어 워커 없음)에는 절대 표시하지 않는다(FR-M2) — 호출부에서
       // 이미 판정하지만, 여기서도 방어적으로 다시 확인한다.
-      if (navigator.serviceWorker.controller === null) return;
+      if (!host.hasController()) return;
       panelEl.hidden = false;
     }
 
@@ -126,7 +144,7 @@ export function initSwUpdate(
       const waiting = registration?.waiting ?? null;
       if (!waiting) return;
       // 최초 설치에서는 controller 가 없으므로 절대 표시하지 않는다(D1-C, FR-M2).
-      if (navigator.serviceWorker.controller === null) return;
+      if (!host.hasController()) return;
       if (dismissedWorker === waiting) return;
       show();
     }
@@ -195,6 +213,8 @@ export function initSwUpdate(
     // 리스너를 쓰면 shortcuts.ts 와 충돌하므로 반드시 panelEl 에 부착한다.
     panelEl.addEventListener("keydown", (e) => {
       if (e.key === "Escape") {
+        // FR-S4 와 동일한 가드(§handleReload): 갱신 진행 중에는 Esc 로도 닫지 않는다.
+        if (panelState === "updating") return;
         e.stopPropagation();
         handleLater();
       }

--- a/tests/swUpdate.test.ts
+++ b/tests/swUpdate.test.ts
@@ -4,11 +4,11 @@ import type { SwUpdateHost } from "../src/swUpdate";
 /**
  * `swUpdate.ts` 는 앱 모듈을 하나도 import 하지 않는 리프 모듈이다(§4.2). 그래서
  * 실제 `navigator.serviceWorker` 없이 가짜 registration + 주입 host 만으로 전량
- * 검증할 수 있다(U9). `navigator.serviceWorker.controller` 판정만은 DI 계약 밖이라
- * (§5.2 표시 판정식) 여기서도 전역 navigator 를 직접 흉내 낸다.
+ * 검증할 수 있다(U9). `navigator.serviceWorker.controller` 판정도 `SwUpdateHost.hasController()`
+ * 로 주입되므로(§5.2 표시 판정식) 전역 `navigator` 를 패치할 필요가 없다.
  *
- * `reloadPending` 은 모듈 스코프 상태(U5)라 테스트 간 누수를 막기 위해 매 테스트마다
- * `vi.resetModules()` 로 모듈을 새로 로드한다.
+ * `reloadPending`·`initialized` 는 모듈 스코프 상태(U5)라 테스트 간 누수를 막기 위해
+ * 매 테스트마다 `vi.resetModules()` 로 모듈을 새로 로드한다.
  */
 async function loadSwUpdate(): Promise<typeof import("../src/swUpdate")> {
   vi.resetModules();
@@ -68,17 +68,13 @@ function makeFakeRegistration(initialWaiting: FakeWorker | null = null) {
   };
 }
 
-function setController(controller: unknown): void {
-  Object.defineProperty(navigator, "serviceWorker", {
-    configurable: true,
-    value: { controller },
-  });
-}
-
 function createPanel(): HTMLElement {
   document.body.innerHTML = `
     <div id="sw-update" data-state="idle" hidden>
-      <p id="sw-update-text"></p>
+      <p id="sw-update-text">
+        <span id="sw-update-text-idle"></span>
+        <span id="sw-update-text-updating" hidden></span>
+      </p>
       <div class="sw-update-actions">
         <button type="button" id="sw-update-later"></button>
         <button type="button" id="sw-update-reload"></button>
@@ -99,6 +95,7 @@ function makeHost(
   hasDirty: ReturnType<typeof vi.fn>;
   confirmUnsafeReload: ReturnType<typeof vi.fn>;
   onControllerChange: ReturnType<typeof vi.fn>;
+  hasController: ReturnType<typeof vi.fn>;
 } {
   const controllerChangeListeners = new Set<() => void>();
   return {
@@ -108,6 +105,9 @@ function makeHost(
       controllerChangeListeners.add(fn);
       return () => controllerChangeListeners.delete(fn);
     }),
+    // 기본값: 이미 설치돼 페이지를 제어 중인 워커가 있는 상태(§5.2 표시 판정의 일반
+    // 케이스). "최초 설치" 시나리오만 개별 테스트에서 false 로 오버라이드한다.
+    hasController: vi.fn(() => true),
     persist: vi.fn(() => true),
     hasDirty: vi.fn(() => false),
     confirmUnsafeReload: vi.fn(() => true),
@@ -136,10 +136,12 @@ describe("swUpdate — 표시 판정 (§5.2)", () => {
   it("controller 없음(최초 설치) + waiting 있음 → 표시하지 않는다 (FR-M2, E1)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController(null);
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
-    const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
+    const host = makeHost(panelEl, {
+      register: vi.fn(async () => registration as never),
+      hasController: vi.fn(() => false),
+    });
 
     initSwUpdate(host);
     await flush();
@@ -151,7 +153,6 @@ describe("swUpdate — 표시 판정 (§5.2)", () => {
   it("controller 있음 + 로드 시점에 waiting 있음 → 1초 지연 후 표시된다 (D1-A, AC-02)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
@@ -171,7 +172,6 @@ describe("swUpdate — 표시 판정 (§5.2)", () => {
   it("controller 있음 + 세션 중 새 워커 설치(경로 B) → 표시된다 (AC-01)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const registration = makeFakeRegistration(null);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
 
@@ -188,7 +188,6 @@ describe("swUpdate — dismiss (D2, AC-10)", () => {
   it("나중에를 누르면 숨겨지고, 동일 워커에는 재표시되지 않는다", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const registration = makeFakeRegistration(null);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
 
@@ -213,7 +212,6 @@ describe("swUpdate — dismiss (D2, AC-10)", () => {
   it("나중에 실행 후 포커스가 지정된 요소로 돌아간다 (I-05)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const registration = makeFakeRegistration(makeFakeWorker());
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
 
@@ -245,7 +243,6 @@ describe("swUpdate — dismiss (D2, AC-10)", () => {
   it("Esc — 알림 내부에 포커스가 있을 때만 닫힌다 (I-06/I-07, FR-S3)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const registration = makeFakeRegistration(makeFakeWorker());
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
 
@@ -262,10 +259,39 @@ describe("swUpdate — dismiss (D2, AC-10)", () => {
     expect(panelEl.hidden).toBe(true);
   });
 
+  it("갱신 진행 중(updating)에는 Esc 를 눌러도 닫히지 않는다 (#10 회귀 방지)", async () => {
+    const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
+    const panelEl = createPanel();
+    const waiting = makeFakeWorker();
+    const registration = makeFakeRegistration(waiting);
+    const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
+
+    initSwUpdate(host);
+    await flush();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(panelEl.hidden).toBe(false);
+
+    // 갱신 시작 — data-state 가 "updating" 으로 전환되고 버튼은 disabled 되지만
+    // Esc 는 클릭과 달리 disabled 로 막히지 않으므로 keydown 핸들러 자체의 가드가
+    // 필요하다(§handleReload 와 동일한 가드를 keydown 에도 적용).
+    panelEl.querySelector<HTMLButtonElement>("#sw-update-reload")!.click();
+    expect(panelEl.dataset.state).toBe("updating");
+
+    const laterBtn = panelEl.querySelector<HTMLButtonElement>("#sw-update-later")!;
+    laterBtn.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect(panelEl.hidden).toBe(false);
+    expect(panelEl.dataset.state).toBe("updating");
+
+    // 타임아웃까지 흘려보내 리로드가 정상적으로 완료되는지도 함께 확인한다
+    // (Esc 가드가 갱신 흐름 자체를 막지는 않아야 한다).
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(host.reload).toHaveBeenCalledOnce();
+  });
+
   it("에디터에서 발생한 Esc 는 알림에 영향을 주지 않는다 (I-07)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const registration = makeFakeRegistration(makeFakeWorker());
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
 
@@ -285,7 +311,6 @@ describe("swUpdate — 갱신 결정 로직 (§8, D3, FR-M5)", () => {
   it("persist() 성공 → 확인 없이 즉시 갱신 진행 (AC-06)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
     const host = makeHost(panelEl, {
@@ -308,7 +333,6 @@ describe("swUpdate — 갱신 결정 로직 (§8, D3, FR-M5)", () => {
   it("persist() 실패 + hasDirty() false → 확인 없이 진행 (잃을 것이 없음)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
     const host = makeHost(panelEl, {
@@ -330,7 +354,6 @@ describe("swUpdate — 갱신 결정 로직 (§8, D3, FR-M5)", () => {
   it("persist() 실패 + hasDirty() true + 취소 → 갱신 중단, 억제 해제 (AC-07/AC-08)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
     const host = makeHost(panelEl, {
@@ -357,7 +380,6 @@ describe("swUpdate — 갱신 결정 로직 (§8, D3, FR-M5)", () => {
   it("persist() 실패 + hasDirty() true + 계속 → 갱신 진행", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
     const host = makeHost(panelEl, {
@@ -382,7 +404,6 @@ describe("swUpdate — 연타 방지 · 타임아웃 · 리로드 (§8.2, U3, FR
   it("연타해도 postMessage 는 1회만 전송된다 (AC-18)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
@@ -401,7 +422,6 @@ describe("swUpdate — 연타 방지 · 타임아웃 · 리로드 (§8.2, U3, FR
   it("controllerchange 수신 시 리로드한다", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
@@ -421,7 +441,6 @@ describe("swUpdate — 연타 방지 · 타임아웃 · 리로드 (§8.2, U3, FR
   it("응답이 없으면 3000ms 뒤 강제로 리로드한다 (FR-S5, AC-19)", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
@@ -441,7 +460,6 @@ describe("swUpdate — 연타 방지 · 타임아웃 · 리로드 (§8.2, U3, FR
   it("controllerchange 와 타임아웃이 경합해도 reload() 는 1회만 호출된다", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const waiting = makeFakeWorker();
     const registration = makeFakeRegistration(waiting);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
@@ -463,7 +481,6 @@ describe("swUpdate — 능동 확인 (§5.5, U6, FR-S1/S2)", () => {
   it("가시성 복귀 시 registration.update() 를 호출한다", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const registration = makeFakeRegistration(null);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
 
@@ -482,7 +499,6 @@ describe("swUpdate — 능동 확인 (§5.5, U6, FR-S1/S2)", () => {
   it("마지막 확인 후 10분 이내의 가시성 복귀는 건너뛴다", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const registration = makeFakeRegistration(null);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
 
@@ -508,7 +524,6 @@ describe("swUpdate — 능동 확인 (§5.5, U6, FR-S1/S2)", () => {
   it("60분 주기로 확인 결과가 변화 없어도 예외 없이 반복 호출된다", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController({});
     const registration = makeFakeRegistration(null);
     const host = makeHost(panelEl, { register: vi.fn(async () => registration as never) });
 
@@ -528,12 +543,12 @@ describe("swUpdate — 견고성 (NFR-2, FR-M13)", () => {
   it("register() 실패는 조용히 무시되고 예외를 전파하지 않는다", async () => {
     const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
     const panelEl = createPanel();
-    setController(null);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const host = makeHost(panelEl, {
       register: vi.fn(async () => {
         throw new Error("등록 실패");
       }),
+      hasController: vi.fn(() => false),
     });
 
     expect(() => initSwUpdate(host)).not.toThrow();
@@ -552,5 +567,31 @@ describe("swUpdate — 견고성 (NFR-2, FR-M13)", () => {
     });
 
     expect(() => initSwUpdate(host)).not.toThrow();
+  });
+
+  it("두 번째 initSwUpdate 호출은 무시되어 setInterval 이 중복 등록되지 않는다 (#12 회귀 방지)", async () => {
+    const { initSwUpdate, isUpdateReloadPending } = await loadSwUpdate();
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const panelEl1 = createPanel();
+    const host1 = makeHost(panelEl1, {
+      register: vi.fn(async () => makeFakeRegistration() as never),
+    });
+    initSwUpdate(host1);
+    await flush();
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    // 동일 모듈 인스턴스에 대해 재호출 — 두 번째 host 의 setInterval 은 등록되지 않아야
+    // 하며(재진입 가드), 경고 로그로 조용히 알려야 한다(NFR-2 와 동일한 견고성 기조).
+    const panelEl2 = createPanel();
+    const host2 = makeHost(panelEl2, {
+      register: vi.fn(async () => makeFakeRegistration() as never),
+    });
+    initSwUpdate(host2);
+    await flush();
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
`Closes #10` `Closes #11` `Closes #12` `Closes #13`

PR #9 코드 리뷰에서 나온 P2 4건. 전부 `src/swUpdate.ts` 한 파일의 소규모 정리(합쳐 10줄 남짓)라 개별 PRD·기술 스펙을 만드는 비용이 산출물 가치를 넘는다고 판단해 한 PR 로 묶었다. **기능 변경은 없다.**

## 수정 내역

### #10 · Esc 가 `updating` 상태에서도 알림을 닫는다

keydown 핸들러가 `panelState` 를 보지 않아, 리로드가 예약된 상태에서 Esc 로 알림이 닫히고 `setPanelState("idle")` 이 버튼을 다시 활성화했다. `handleReload()` 와 동일한 가드를 추가했다.

### #11 · host 를 우회해 전역 `navigator` 를 읽는다

`SwUpdateHost` 에 `hasController()` 를 추가하고 호출부 2곳을 host 경유로 바꿨다.

**실질 이득은 테스트다.** `tests/swUpdate.test.ts` 의 전역 navigator 패치가 **완전히 사라졌다**.

```diff
- Object.defineProperty(navigator, "serviceWorker", { value: { controller } });
+ makeHost(panelEl, { hasController: () => true })
```

DI 계약이 완결됐고, `navigator.serviceWorker` 부재 환경에서 비동기 콜백이 TypeError 를 던지던 잠재 경로도 없어졌다(`initSwUpdate` 의 try/catch 는 동기 초기화만 감싼다).

### #12 · `setInterval` 이 정리되지 않는다

**정리 함수 대신 재진입 가드**를 택했다. `initSwUpdate` 를 해제하는 호출자가 없는 SPA 라 정리 함수는 죽은 코드가 된다. 기존 `reloadPending` 과 같은 모듈 스코프 플래그 컨벤션을 따랐다.

### #13 · 정적 문구를 `innerHTML` 로 주입

`index.html` 에 상호 배타적인 두 span(idle/updating)을 두고 `hidden` 토글로 바꿨다. 상태 전이가 마크업에 드러나고, 기존 버튼 `disabled` 토글 패턴과 일관된다. `CLAUDE.md` 의 "`parseMarkdown()` 을 우회해 `innerHTML` 을 쓰지 않는다" 규칙에서 예외가 사라졌다.

## 회귀 단언을 실제로 검증했다

F-69 에서 `MutationObserver` 단언이 vacuous 였던 전례가 있어, 신규 테스트 2건을 각각 **수정 전 코드로 되돌려** 실제로 실패하는지 확인했다.

| 테스트 | 수정 되돌렸을 때 |
|--------|------------------|
| #10 `updating` 중 Esc 무시 | `AssertionError: expected true to be false` |
| #12 재진입 시 타이머 1회만 | `expected "setInterval" to be called 1 times, but got 2 times` |

둘 다 원복 후 재확인했다. 단언이 무엇을 보호하는지 확인하지 않으면 없는 것만 못하다.

## 검증

| 항목 | 결과 |
|------|------|
| `tsc --noEmit` | 오류 0 |
| `npm run build` | 성공 |
| 단위 | **44/44** (기존 42 + 신규 2) |
| E2E (dev 서버) | 79 통과 / 15 skip |
| E2E (프리뷰) `swupdate.spec.ts` | 10/10 |

**회귀 0.** `#sw-update*` id, `#notice` 계약, 캐시 전략, `skipWaiting()` 제거, `postMessage` 대상 등 F-69 핵심 결정은 전부 그대로다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CtFxzJ9wgUjid5dDvZBNm