### PR TITLE
refactor: 텍스트 조작 순수 함수 추출 + 단위 테스트 (F-47 1단계)

### DIFF
--- a/docs/architecture/traceability.md
+++ b/docs/architecture/traceability.md
@@ -61,13 +61,14 @@ graph LR
   shortcuts --> fileOps
   shortcuts --> tabs
   toolbar -. "setFileActions() 콜백 주입" .-> fileOps
+  toolbar --> textEdit["textEdit.ts"]
 
   classDef leaf fill:#eef,stroke:#88a
-  class parser,storage,notice,swUpdate leaf
+  class parser,storage,notice,swUpdate,textEdit leaf
 ```
 
 - **순환 의존 없음.** `toolbar.ts` 는 `fileOps` 를 import 하지 않고 `setFileActions()` 로 콜백을 주입받아 역방향 의존을 끊는다.
-- `parser.ts` · `storage.ts` · `notice.ts` · `swUpdate.ts` 는 다른 앱 모듈에 의존하지 않는 리프다. 이 중 단위 테스트가 붙은 것은 `parser.ts`(100%) · `storage.ts`(91.4%) · `swUpdate.ts`(78.9%) — **테스트 용이성과 의존 방향이 정확히 일치한다.** `swUpdate.ts` 는 `SwUpdateHost` 주입으로 이 성질을 의도적으로 확보했다.
+- `parser.ts` · `storage.ts` · `notice.ts` · `swUpdate.ts` · `textEdit.ts` 는 다른 앱 모듈에 의존하지 않는 리프다. 이 중 단위 테스트가 붙은 것은 `parser.ts`(100%) · `storage.ts`(91.4%) · `swUpdate.ts`(78.9%) · `textEdit.ts`(신규) — **테스트 용이성과 의존 방향이 정확히 일치한다.** `swUpdate.ts` 는 `SwUpdateHost` 주입, `textEdit.ts` 는 DOM 삽입과 문자열 계산을 분리해 이 성질을 의도적으로 확보했다.
 
 ## 3. 상태 필드 ↔ 소비처 역방향 인덱스
 
@@ -113,6 +114,7 @@ graph LR
 | `tsconfig.json` · `package.json` build | [인프라 §3.3](./infrastructure.md) |
 | `src/fileOps.ts` (파일 I/O 분기) | [API 명세 §2·§3](../api/browser-apis.md), [서비스 아키텍처 §5.3](./service-architecture.md) |
 | `src/toolbar.ts` (버튼 증감) | [기능 현황](../features/feature-status.md), `tests/e2e/toolbar.spec.ts` 버튼 개수 단언 |
+| `src/textEdit.ts` (감싸기·줄머리·블록 삽입 계산) | `tests/textEdit.test.ts`, `tests/e2e/toolbar.spec.ts` (동작 회귀 게이트) |
 | `src/shortcuts.ts` | [API 명세 §5](../api/browser-apis.md#5-키보드-단축키), [사용자 시나리오](../user-scenarios.md), README 단축키 표 |
 | `src/notice.ts` | [API 명세](../api/browser-apis.md), `fileaccess.spec.ts` |
 | `vite.config.ts` · `wrangler.jsonc` · `.github/workflows/*` | [인프라 아키텍처](./infrastructure.md), [CF Workers 구성](../operations/cloudflare-workers.md) |

--- a/src/fileOps.ts
+++ b/src/fileOps.ts
@@ -187,7 +187,9 @@ function downloadFile(content: string, fileName: string): void {
   URL.revokeObjectURL(url);
 }
 
-function suggestFileName(fileName: string): string {
+/** 순수 함수 — 저장 대화상자에 제안할 파일명 계산. UNTITLED/공백은 "Untitled.md",
+ * 이미 마크다운류 확장자면 그대로, 아니면 ".md" 를 붙인다. */
+export function suggestFileName(fileName: string): string {
   if (fileName === UNTITLED || fileName.trim() === "") return "Untitled.md";
   return /\.(md|markdown|txt)$/i.test(fileName) ? fileName : `${fileName}.md`;
 }

--- a/src/textEdit.ts
+++ b/src/textEdit.ts
@@ -1,0 +1,63 @@
+/**
+ * 텍스트 조작의 순수 계산 부분.
+ *
+ * `toolbar.ts` 의 `wrapSelection`·`insertAtLineStart`·`insertBlock` 은 이 모듈이
+ * 계산한 결과를 받아 `document.execCommand("insertText")` 로 실제 DOM 삽입만 수행하는
+ * 얇은 껍데기다. `textarea.value` 를 직접 대입하면 `Cmd+Z` undo 스택이 깨지므로
+ * (docs/user-scenarios.md US-05) DOM 삽입 방식은 여전히 execCommand 를 쓴다 — 이 모듈은
+ * "무엇을 삽입할지" 만 계산하고 "어떻게 삽입할지" 는 모른다.
+ *
+ * DOM 타입을 인자로 받지 않는다. 다른 앱 모듈에도 의존하지 않는 리프 모듈이다
+ * (docs/architecture/traceability.md §2 의존 그래프 참고).
+ */
+
+export interface WrapResult {
+  /** execCommand("insertText")로 선택 영역에 삽입할 문자열 */
+  replacement: string;
+  /**
+   * 원래 선택 영역이 비어 있었을 때만 채워짐 — 삽입 후 placeholder 를 다시
+   * 선택 상태로 만들기 위한 범위. 선택 영역이 있었으면 null (브라우저가 삽입
+   * 지점으로 커서를 자동 이동시키므로 별도 처리 불필요).
+   */
+  placeholderSelection: { start: number; end: number } | null;
+}
+
+const DEFAULT_PLACEHOLDER = "텍스트";
+
+/** `before`/`after` 로 선택 영역을 감싼다 (Bold/Italic/Strikethrough/Code 등). */
+export function computeWrap(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  before: string,
+  after: string,
+  placeholder: string = DEFAULT_PLACEHOLDER,
+): WrapResult {
+  const selected = value.slice(selectionStart, selectionEnd);
+  const replacement = `${before}${selected || placeholder}${after}`;
+
+  if (selected) {
+    return { replacement, placeholderSelection: null };
+  }
+
+  const start = selectionStart + before.length;
+  return {
+    replacement,
+    placeholderSelection: { start, end: start + placeholder.length },
+  };
+}
+
+/** 커서가 속한 줄의 시작 인덱스 (Heading/List/Blockquote 접두어 삽입 지점). */
+export function computeLineStart(value: string, selectionStart: number): number {
+  return value.lastIndexOf("\n", selectionStart - 1) + 1;
+}
+
+/** 블록 요소(Horizontal Rule 등) 삽입 문자열. 커서 앞에 개행이 없으면 하나 보충한다. */
+export function computeBlockInsertion(
+  value: string,
+  selectionStart: number,
+  text: string,
+): string {
+  const needsNewline = selectionStart > 0 && value[selectionStart - 1] !== "\n";
+  return needsNewline ? `\n${text}\n` : `${text}\n`;
+}

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -1,3 +1,5 @@
+import { computeBlockInsertion, computeLineStart, computeWrap } from "./textEdit";
+
 interface ToolbarAction {
   label: string;
   icon: string;
@@ -11,31 +13,37 @@ interface ToolbarAction {
   editsText?: boolean;
 }
 
+// 계산(무엇을 삽입할지)은 순수 함수인 ./textEdit 에 있다. 아래 세 함수는 DOM 삽입
+// (어떻게 삽입할지)만 담당하는 얇은 껍데기다 — execCommand("insertText") 를 유지해야
+// Cmd+Z undo 스택이 보존된다 (docs/user-scenarios.md US-05).
+
 function wrapSelection(
   textarea: HTMLTextAreaElement,
   before: string,
   after: string,
 ) {
   const { selectionStart, selectionEnd, value } = textarea;
-  const selected = value.slice(selectionStart, selectionEnd);
-  const replacement = `${before}${selected || "텍스트"}${after}`;
+  const { replacement, placeholderSelection } = computeWrap(
+    value,
+    selectionStart,
+    selectionEnd,
+    before,
+    after,
+  );
 
   textarea.focus();
   textarea.setSelectionRange(selectionStart, selectionEnd);
   document.execCommand("insertText", false, replacement);
 
   // 선택 텍스트가 없었으면 placeholder를 선택 상태로
-  if (!selected) {
-    textarea.setSelectionRange(
-      selectionStart + before.length,
-      selectionStart + before.length + "텍스트".length,
-    );
+  if (placeholderSelection) {
+    textarea.setSelectionRange(placeholderSelection.start, placeholderSelection.end);
   }
 }
 
 function insertAtLineStart(textarea: HTMLTextAreaElement, prefix: string) {
   const { selectionStart, value } = textarea;
-  const lineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
+  const lineStart = computeLineStart(value, selectionStart);
 
   textarea.focus();
   textarea.setSelectionRange(lineStart, lineStart);
@@ -44,8 +52,7 @@ function insertAtLineStart(textarea: HTMLTextAreaElement, prefix: string) {
 
 function insertBlock(textarea: HTMLTextAreaElement, text: string) {
   const { selectionStart, value } = textarea;
-  const needsNewline = selectionStart > 0 && value[selectionStart - 1] !== "\n";
-  const insertion = needsNewline ? `\n${text}\n` : `${text}\n`;
+  const insertion = computeBlockInsertion(value, selectionStart, text);
 
   textarea.focus();
   textarea.setSelectionRange(selectionStart, selectionStart);

--- a/tests/fileOps.test.ts
+++ b/tests/fileOps.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { suggestFileName } from "../src/fileOps";
+
+describe("suggestFileName", () => {
+  it("UNTITLED 이면 Untitled.md 를 제안한다", () => {
+    expect(suggestFileName("Untitled")).toBe("Untitled.md");
+  });
+
+  it("공백 문자열이면 Untitled.md 를 제안한다", () => {
+    expect(suggestFileName("   ")).toBe("Untitled.md");
+  });
+
+  it("빈 문자열이면 Untitled.md 를 제안한다", () => {
+    expect(suggestFileName("")).toBe("Untitled.md");
+  });
+
+  it(".md 확장자는 그대로 유지한다", () => {
+    expect(suggestFileName("notes.md")).toBe("notes.md");
+  });
+
+  it(".markdown 확장자는 그대로 유지한다", () => {
+    expect(suggestFileName("notes.markdown")).toBe("notes.markdown");
+  });
+
+  it(".txt 확장자는 그대로 유지한다", () => {
+    expect(suggestFileName("notes.txt")).toBe("notes.txt");
+  });
+
+  it("대소문자가 섞인 확장자(.MD)도 인식해 그대로 유지한다", () => {
+    expect(suggestFileName("notes.MD")).toBe("notes.MD");
+  });
+
+  it("확장자가 없으면 .md 를 붙인다", () => {
+    expect(suggestFileName("notes")).toBe("notes.md");
+  });
+
+  it("지원하지 않는 확장자면 .md 를 덧붙인다", () => {
+    expect(suggestFileName("notes.doc")).toBe("notes.doc.md");
+  });
+});

--- a/tests/textEdit.test.ts
+++ b/tests/textEdit.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { computeBlockInsertion, computeLineStart, computeWrap } from "../src/textEdit";
+
+describe("computeWrap", () => {
+  it("선택 영역이 없으면 placeholder 를 감싸고 재선택 범위를 반환한다", () => {
+    const result = computeWrap("hello", 5, 5, "**", "**");
+    expect(result.replacement).toBe("**텍스트**");
+    expect(result.placeholderSelection).toEqual({ start: 7, end: 10 });
+  });
+
+  it("선택 영역이 있으면 그 텍스트를 감싸고 재선택 범위는 null 이다", () => {
+    const result = computeWrap("hello world", 0, 5, "**", "**");
+    expect(result.replacement).toBe("**hello**");
+    expect(result.placeholderSelection).toBeNull();
+  });
+
+  it("빈 문자열에서 커서가 0 이어도 placeholder 를 삽입한다", () => {
+    const result = computeWrap("", 0, 0, "*", "*");
+    expect(result.replacement).toBe("*텍스트*");
+    expect(result.placeholderSelection).toEqual({ start: 1, end: 4 });
+  });
+
+  it("커서가 문서 끝에 있어도 동일하게 동작한다", () => {
+    const value = "abc";
+    const result = computeWrap(value, value.length, value.length, "`", "`");
+    expect(result.replacement).toBe("`텍스트`");
+    expect(result.placeholderSelection).toEqual({ start: 4, end: 7 });
+  });
+
+  it("before/after 가 비대칭이어도 재선택 범위는 before 길이만큼 밀린다", () => {
+    const result = computeWrap("x", 1, 1, "~~", "~~");
+    expect(result.placeholderSelection?.start).toBe(3);
+  });
+});
+
+describe("computeLineStart", () => {
+  it("문서 첫 줄에서는 0을 반환한다", () => {
+    expect(computeLineStart("hello", 3)).toBe(0);
+  });
+
+  it("두 번째 줄 중간에서는 개행 다음 인덱스를 반환한다", () => {
+    const value = "first\nsecond";
+    // "second" 는 인덱스 6부터 시작, 커서가 "sec|ond" 위치(9)라 가정
+    expect(computeLineStart(value, 9)).toBe(6);
+  });
+
+  it("빈 문자열에서 커서 0이면 0을 반환한다", () => {
+    expect(computeLineStart("", 0)).toBe(0);
+  });
+
+  it("줄 맨 앞(개행 직후)에서도 그 줄의 시작을 반환한다", () => {
+    const value = "a\nb";
+    expect(computeLineStart(value, 2)).toBe(2);
+  });
+});
+
+describe("computeBlockInsertion", () => {
+  it("개행 직후(커서 바로 앞이 \\n)면 앞에 개행을 보충하지 않는다", () => {
+    const value = "line1\n";
+    expect(computeBlockInsertion(value, value.length, "---")).toBe("---\n");
+  });
+
+  it("개행이 아닌 위치(줄 중간 끝)면 앞에 개행을 보충한다", () => {
+    const value = "line1";
+    expect(computeBlockInsertion(value, value.length, "---")).toBe("\n---\n");
+  });
+
+  it("커서가 문서 맨 앞(0)이면 개행을 보충하지 않는다", () => {
+    expect(computeBlockInsertion("", 0, "---")).toBe("---\n");
+  });
+
+  it("커서가 0보다 크고 직전 문자가 개행이 아니면 보충한다", () => {
+    expect(computeBlockInsertion("ab", 2, "---")).toBe("\n---\n");
+  });
+});


### PR DESCRIPTION
`Refs #16` — 로드맵 **1단계만**. `tabs.ts` 는 건드리지 않았다(2단계 별도 PR).

한 PR 로 60% 까지 밀면 리뷰 불가능한 크기가 되므로 나눴다.

## 왜 이 방식인가 — 이 세션에서 두 번 확인된 처방

| 사례 | 결과 |
|------|------|
| F-69 `swUpdate.ts` 를 DI 주입형 리프로 설계 | 실제 `navigator.serviceWorker` 없이 **79%** 검증 |
| P2 #11 에서 `hasController()` 를 host 로 이동 | 테스트의 전역 `navigator` 패치가 **통째로 사라짐** |

**커버리지는 테스트를 더 써서가 아니라 의존 방향을 정리해서 오른다.** 같은 처방을 적용했다.

## 추출

`src/textEdit.ts` (신규 리프) — `computeWrap` · `computeLineStart` · `computeBlockInsertion`. **DOM 타입을 인자로 받지 않고** 문자열 계산만 한다.

`toolbar.ts` 의 세 함수는 이제 계산 결과를 받아 `execCommand("insertText")` 로 삽입만 하는 얇은 껍데기다.

**별도 파일로 뺀 이유**: `toolbar.ts` 는 DOM 부수효과(`execCommand`, `focus`)를 가진 버튼 정의 16개와 `initToolbar()` 를 담고 있다. 순수 함수를 같은 파일에 두면 "이 파일은 DOM-free" 라는 보장이 **파일 단위로** 깨진다. `swUpdate.ts` 가 얻은 성질을 재현하려면 물리적 분리가 필요하다. 순환 없음(`toolbar → textEdit` 단방향).

`fileOps.suggestFileName` 은 이미 순수해서 `export` 만 추가했다.

## 동작 보존이 이 PR 의 전부다

**`execCommand("insertText")` 를 유지했다.** `textarea.value` 직접 대입으로 바꾸면 `Cmd+Z` undo 스택이 깨진다 — 이 프로젝트가 의도적으로 지켜온 설계다(`docs/user-scenarios.md` US-05).

`tests/e2e/toolbar.spec.ts` **16건 전부 통과** = 삽입 결과 문자열이 한 글자도 안 바뀌었다.

## 테스트

`textEdit.test.ts` 13건 + `fileOps.test.ts` 9건. 경계 조건 중심 — 선택 없음/있음, 문서 첫 줄 줄머리, 개행 직후 여부에 따른 블록 삽입 분기, 빈 문자열, 커서 끝, 확장자 대소문자.

### 단언이 실제로 회귀를 잡는지 확인했다

이 세션에서 vacuous 단언을 이미 겪었기에(F-69 `MutationObserver`) 매번 확인한다. 순수 함수 로직에 **의도적 버그를 주입**했다.

| 주입한 버그 | 실패한 테스트 |
|-------------|---------------|
| `computeWrap` 오프바이원 | 4/13 |
| `computeBlockInsertion` 의 `needsNewline` 고정 | 2/13 |
| `suggestFileName` 트림 조건 제거 | 2/9 |

전부 원복 확인.

## 커버리지

| 지표 | 기준선 | 현재 |
|------|--------|------|
| Lines | 26.07% | **30.45%** |
| `textEdit.ts` | — | **100%** |

## 검증

tsc 0 / 빌드 성공 / E2E dev 79 통과·15 skip / **`toolbar.spec.ts` 16/16** / 프리뷰 swupdate 10건 — 회귀 0.

## 다음 단계

2단계(`tabs.ts` 단위 테스트, ~60% 목표)는 이 PR 머지 후 실제 수치를 보고 별도 PR 로 진행한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CtFxzJ9wgUjid5dDvZBNm