### PR TITLE
test: tabs.ts 단위 테스트 + 리프 보강 (F-47 2단계, 라인 60.15%)

### DIFF
--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEditor } from "../src/editor";
+
+function createDom(): { editorEl: HTMLTextAreaElement; previewEl: HTMLElement } {
+  document.body.innerHTML = `<textarea id="editor"></textarea><div id="preview"></div>`;
+  return {
+    editorEl: document.querySelector<HTMLTextAreaElement>("#editor")!,
+    previewEl: document.querySelector<HTMLElement>("#preview")!,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createEditor", () => {
+  it("초기화 시 현재 textarea 값을 즉시 프리뷰에 렌더링한다", () => {
+    const { editorEl, previewEl } = createDom();
+    editorEl.value = "# 초기 제목";
+
+    createEditor({ editorEl, previewEl });
+
+    expect(previewEl.innerHTML).toContain("<h1");
+  });
+
+  it("input 이벤트는 디바운스 후에만 프리뷰를 갱신한다", () => {
+    const { editorEl, previewEl } = createDom();
+    createEditor({ editorEl, previewEl, debounceMs: 150 });
+
+    editorEl.value = "본문 입력";
+    editorEl.dispatchEvent(new Event("input"));
+
+    // 디바운스 시간이 지나기 전에는 아직 갱신되지 않는다.
+    expect(previewEl.innerHTML).not.toContain("본문 입력");
+
+    vi.advanceTimersByTime(150);
+    expect(previewEl.innerHTML).toContain("본문 입력");
+  });
+
+  it("디바운스 시간 내 연속 입력은 마지막 값 한 번만 렌더링한다", () => {
+    const { editorEl, previewEl } = createDom();
+    createEditor({ editorEl, previewEl, debounceMs: 150 });
+
+    editorEl.value = "첫";
+    editorEl.dispatchEvent(new Event("input"));
+    vi.advanceTimersByTime(100);
+
+    editorEl.value = "두번째";
+    editorEl.dispatchEvent(new Event("input"));
+    vi.advanceTimersByTime(100);
+    // 첫 타이머(150ms) 시점이 지났어도 재설정됐으므로 아직 갱신되지 않는다.
+    expect(previewEl.innerHTML).not.toContain("두번째");
+
+    vi.advanceTimersByTime(50);
+    expect(previewEl.innerHTML).toContain("두번째");
+    expect(previewEl.innerHTML).not.toContain("첫");
+  });
+
+  it("debounceMs 기본값은 150ms 다", () => {
+    const { editorEl, previewEl } = createDom();
+    createEditor({ editorEl, previewEl });
+
+    editorEl.value = "기본 디바운스";
+    editorEl.dispatchEvent(new Event("input"));
+
+    vi.advanceTimersByTime(149);
+    expect(previewEl.innerHTML).not.toContain("기본 디바운스");
+
+    vi.advanceTimersByTime(1);
+    expect(previewEl.innerHTML).toContain("기본 디바운스");
+  });
+});

--- a/tests/notice.test.ts
+++ b/tests/notice.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hideNotice, initNotice, showNotice } from "../src/notice";
+
+function createContainer(): HTMLElement {
+  document.body.innerHTML = `<div id="notice" hidden></div>`;
+  return document.querySelector<HTMLElement>("#notice")!;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("showNotice", () => {
+  it("메시지와 종류를 렌더링하고 hidden 을 해제한다", () => {
+    const container = createContainer();
+    initNotice(container);
+
+    showNotice("저장됐습니다", "info");
+
+    expect(container.hidden).toBe(false);
+    expect(container.textContent).toBe("저장됐습니다");
+    expect(container.dataset.kind).toBe("info");
+  });
+
+  it("durationMs 후 자동으로 숨긴다", () => {
+    const container = createContainer();
+    initNotice(container);
+
+    showNotice("에러 발생", "error", 1000);
+    expect(container.hidden).toBe(false);
+
+    vi.advanceTimersByTime(999);
+    expect(container.hidden).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(container.hidden).toBe(true);
+  });
+
+  it("이전 타이머가 남아 있으면 취소하고 새 타이머로 교체한다", () => {
+    const container = createContainer();
+    initNotice(container);
+
+    showNotice("첫 알림", "info", 1000);
+    vi.advanceTimersByTime(500);
+    // 아직 첫 타이머가 끝나기 전에 새 알림을 띄운다.
+    showNotice("두번째 알림", "error", 1000);
+
+    // 첫 타이머 시점(500ms 추가 경과 = 총 1000ms)에는 숨겨지지 않아야 한다 —
+    // 이전 타이머가 취소되고 새 타이머(두번째 알림 기준 1000ms)로 교체됐기 때문이다.
+    vi.advanceTimersByTime(500);
+    expect(container.hidden).toBe(false);
+    expect(container.textContent).toBe("두번째 알림");
+
+    vi.advanceTimersByTime(500);
+    expect(container.hidden).toBe(true);
+  });
+
+  it("initNotice 를 호출하지 않았으면 아무 것도 하지 않는다", () => {
+    expect(() => showNotice("무시됨")).not.toThrow();
+  });
+
+  it("기본 kind 는 info, 기본 durationMs 는 4000 이다", () => {
+    const container = createContainer();
+    initNotice(container);
+
+    showNotice("기본값 확인");
+    expect(container.dataset.kind).toBe("info");
+
+    vi.advanceTimersByTime(3999);
+    expect(container.hidden).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(container.hidden).toBe(true);
+  });
+});
+
+describe("hideNotice", () => {
+  it("표시 중인 알림을 즉시 숨기고 대기 중인 타이머를 취소한다", () => {
+    const container = createContainer();
+    initNotice(container);
+
+    showNotice("알림", "info", 5000);
+    expect(container.hidden).toBe(false);
+
+    hideNotice();
+    expect(container.hidden).toBe(true);
+
+    // 타이머가 취소됐으므로 이후 시간이 흘러도 예외 없이 안전하다.
+    expect(() => vi.advanceTimersByTime(10000)).not.toThrow();
+  });
+
+  it("containerEl 이 없으면 아무 것도 하지 않는다", () => {
+    // initNotice() 를 호출하지 않은 상태를 재현하기 어려우므로(모듈 스코프 상태가
+    // 이전 테스트에서 남음), 최소한 예외 없이 안전하게 동작하는지만 확인한다.
+    expect(() => hideNotice()).not.toThrow();
+  });
+});

--- a/tests/shortcuts.test.ts
+++ b/tests/shortcuts.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `shortcuts.ts` 는 `fileOps.ts`(파일 I/O, 이번 범위 밖)와 `tabs.ts` 를 직접 호출한다.
+ * 키 매핑 자체만 검증하면 되므로 두 모듈을 전부 모킹해 `document` 의 keydown 리스너
+ * 동작만 격리해서 확인한다.
+ */
+vi.mock("../src/fileOps", () => ({
+  openFile: vi.fn(),
+  saveFile: vi.fn(),
+  saveFileAs: vi.fn(),
+}));
+
+vi.mock("../src/tabs", () => ({
+  UNTITLED: "Untitled",
+  closeTab: vi.fn(),
+  createTab: vi.fn(),
+  getActiveTab: vi.fn(),
+}));
+
+import { openFile, saveFile, saveFileAs } from "../src/fileOps";
+import { UNTITLED, closeTab, createTab, getActiveTab } from "../src/tabs";
+import { initShortcuts } from "../src/shortcuts";
+
+function dispatchKeydown(init: KeyboardEventInit): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", { ...init, cancelable: true });
+  document.dispatchEvent(event);
+  return event;
+}
+
+// initShortcuts() 는 document 에 keydown 리스너를 등록만 하고 참조를 돌려주지
+// 않는다. 테스트마다 새로 호출하면 리스너가 계속 쌓여 이벤트가 여러 번 처리되므로,
+// addEventListener 를 스파이해 핸들러를 붙잡아뒀다가 매 테스트 후 직접 제거한다.
+let capturedHandler: EventListenerOrEventListenerObject | null = null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const spy = vi.spyOn(document, "addEventListener");
+  initShortcuts();
+  capturedHandler = spy.mock.calls[0]?.[1] as EventListenerOrEventListenerObject;
+  spy.mockRestore();
+});
+
+afterEach(() => {
+  if (capturedHandler) document.removeEventListener("keydown", capturedHandler);
+  capturedHandler = null;
+});
+
+describe("initShortcuts — 파일 단축키", () => {
+  it("Cmd/Ctrl+O 는 openFile() 을 호출하고 기본 동작을 막는다", () => {
+    const event = dispatchKeydown({ key: "o", metaKey: true });
+    expect(openFile).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("Cmd/Ctrl+S(shift 없음) 는 saveFile() 을 호출한다", () => {
+    dispatchKeydown({ key: "s", metaKey: true });
+    expect(saveFile).toHaveBeenCalledTimes(1);
+    expect(saveFileAs).not.toHaveBeenCalled();
+  });
+
+  it("Cmd/Ctrl+Shift+S 는 saveFileAs() 를 호출한다", () => {
+    dispatchKeydown({ key: "s", metaKey: true, shiftKey: true });
+    expect(saveFileAs).toHaveBeenCalledTimes(1);
+    expect(saveFile).not.toHaveBeenCalled();
+  });
+
+  it("ctrlKey 로도 동일하게 동작한다 (metaKey 대체)", () => {
+    dispatchKeydown({ key: "o", ctrlKey: true });
+    expect(openFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("매핑되지 않은 mod+키는 아무 것도 호출하지 않는다", () => {
+    dispatchKeydown({ key: "x", metaKey: true });
+    expect(openFile).not.toHaveBeenCalled();
+    expect(saveFile).not.toHaveBeenCalled();
+    expect(saveFileAs).not.toHaveBeenCalled();
+  });
+});
+
+describe("initShortcuts — 탭 단축키 (Alt)", () => {
+  it("Alt+N 은 새 Untitled 탭을 만든다", () => {
+    const event = dispatchKeydown({ code: "KeyN", altKey: true });
+    expect(createTab).toHaveBeenCalledWith("", null, UNTITLED);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("Alt+W 는 활성 탭이 있으면 closeTab(id) 을 호출한다", () => {
+    vi.mocked(getActiveTab).mockReturnValue({ id: "tab-3" } as ReturnType<
+      typeof getActiveTab
+    >);
+
+    const event = dispatchKeydown({ code: "KeyW", altKey: true });
+    expect(closeTab).toHaveBeenCalledWith("tab-3");
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("Alt+W 인데 활성 탭이 없으면 closeTab 을 호출하지 않는다", () => {
+    vi.mocked(getActiveTab).mockReturnValue(undefined);
+
+    dispatchKeydown({ code: "KeyW", altKey: true });
+    expect(closeTab).not.toHaveBeenCalled();
+  });
+
+  it("매핑되지 않은 Alt+키는 아무 것도 호출하지 않는다", () => {
+    dispatchKeydown({ code: "KeyZ", altKey: true });
+    expect(createTab).not.toHaveBeenCalled();
+    expect(closeTab).not.toHaveBeenCalled();
+  });
+});
+
+describe("initShortcuts — 수식어 조합", () => {
+  it("mod 와 Alt 가 동시에 눌리면 어느 분기도 타지 않는다", () => {
+    dispatchKeydown({ key: "o", metaKey: true, altKey: true });
+    dispatchKeydown({ code: "KeyN", metaKey: true, altKey: true });
+
+    expect(openFile).not.toHaveBeenCalled();
+    expect(createTab).not.toHaveBeenCalled();
+  });
+
+  it("수식어가 전혀 없으면 아무 것도 호출하지 않는다", () => {
+    dispatchKeydown({ key: "s" });
+    dispatchKeydown({ code: "KeyN" });
+
+    expect(saveFile).not.toHaveBeenCalled();
+    expect(createTab).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -1,0 +1,626 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSession, saveSession, type PersistedTab } from "../src/storage";
+
+/**
+ * `tabs.ts` 는 모듈 스코프 싱글턴(`tabs` Map, `activeTabId`, `nextId`, ...)을 쓰므로
+ * 테스트 간 상태가 새면 ID 시퀀스·활성 탭 판정이 뒤섞인다. `swUpdate.test.ts` 의
+ * `loadSwUpdate()` 패턴을 따라 매 테스트마다 `vi.resetModules()` 로 모듈을 새로
+ * 로드해 격리한다.
+ */
+async function loadTabs(): Promise<typeof import("../src/tabs")> {
+  vi.resetModules();
+  return import("../src/tabs");
+}
+
+interface Dom {
+  tabBar: HTMLElement;
+  editor: HTMLTextAreaElement;
+  preview: HTMLElement;
+  title: HTMLElement;
+  notice: HTMLElement;
+}
+
+function createDom(): Dom {
+  document.body.innerHTML = `
+    <div id="tab-bar"></div>
+    <textarea id="editor"></textarea>
+    <div id="preview"></div>
+    <div id="title"></div>
+    <div id="notice" hidden></div>
+  `;
+  return {
+    tabBar: document.querySelector<HTMLElement>("#tab-bar")!,
+    editor: document.querySelector<HTMLTextAreaElement>("#editor")!,
+    preview: document.querySelector<HTMLElement>("#preview")!,
+    title: document.querySelector<HTMLElement>("#title")!,
+    notice: document.querySelector<HTMLElement>("#notice")!,
+  };
+}
+
+/** 가짜 FileSystemFileHandle. isSameEntry() 만 비동기 스파이로 흉내낸다. */
+function makeFakeHandle(
+  matches: (other: unknown) => boolean,
+): FileSystemFileHandle {
+  return {
+    isSameEntry: vi.fn(async (other: unknown) => matches(other)),
+  } as unknown as FileSystemFileHandle;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createTab", () => {
+  it("ID 시퀀스가 tab-1 부터 순차 증가한다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    // initTabs() 가 복원할 세션이 없으면 기본 Untitled 탭(tab-1)을 만든다.
+    expect(tabs.getActiveTab()!.id).toBe("tab-1");
+
+    const second = tabs.createTab();
+    const third = tabs.createTab();
+    expect(second).toBe("tab-2");
+    expect(third).toBe("tab-3");
+  });
+
+  it("기본값(content/handle/fileName/isDirty/scroll/selection)을 갖는다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const id = tabs.createTab();
+    const tab = tabs.getAllTabs().find((t) => t.id === id)!;
+    expect(tab.content).toBe("");
+    expect(tab.handle).toBeNull();
+    expect(tab.fileName).toBe(tabs.UNTITLED);
+    expect(tab.isDirty).toBe(false);
+    expect(tab.scrollTop).toBe(0);
+    expect(tab.selectionStart).toBe(0);
+    expect(tab.selectionEnd).toBe(0);
+  });
+
+  it("인자로 넘긴 content/handle/fileName 을 그대로 반영한다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const handle = makeFakeHandle(() => false);
+    const id = tabs.createTab("본문", handle, "note.md");
+    const tab = tabs.getAllTabs().find((t) => t.id === id)!;
+    expect(tab.content).toBe("본문");
+    expect(tab.handle).toBe(handle);
+    expect(tab.fileName).toBe("note.md");
+  });
+
+  it("생성 즉시 활성 탭이 되고 에디터에 내용이 반영된다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const id = tabs.createTab("hello world");
+    expect(tabs.getActiveTab()!.id).toBe(id);
+    expect(dom.editor.value).toBe("hello world");
+  });
+});
+
+describe("switchTab", () => {
+  it("떠나는 탭의 content/scrollTop/selection 을 스냅샷으로 저장한다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const firstId = tabs.getActiveTab()!.id;
+    dom.editor.value = "첫 탭 수정된 내용";
+    dom.editor.scrollTop = 77;
+    dom.editor.focus();
+    dom.editor.setSelectionRange(2, 5);
+
+    const secondId = tabs.createTab("두번째 탭");
+
+    const firstTab = tabs.getAllTabs().find((t) => t.id === firstId)!;
+    expect(firstTab.content).toBe("첫 탭 수정된 내용");
+    expect(firstTab.scrollTop).toBe(77);
+    expect(firstTab.selectionStart).toBe(2);
+    expect(firstTab.selectionEnd).toBe(5);
+    expect(tabs.getActiveTab()!.id).toBe(secondId);
+  });
+
+  it("대상 탭으로 전환하면 content/scrollTop/selection 이 복원된다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const firstId = tabs.getActiveTab()!.id;
+    dom.editor.value = "탭1 내용";
+    dom.editor.scrollTop = 10;
+    dom.editor.focus();
+    dom.editor.setSelectionRange(1, 3);
+
+    tabs.createTab("탭2 내용");
+
+    tabs.switchTab(firstId);
+
+    expect(dom.editor.value).toBe("탭1 내용");
+    expect(dom.editor.scrollTop).toBe(10);
+    expect(dom.editor.selectionStart).toBe(1);
+    expect(dom.editor.selectionEnd).toBe(3);
+  });
+
+  it("focus() 를 setSelectionRange() 보다 먼저 호출한다 (F-69 순서 보장)", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const firstId = tabs.getActiveTab()!.id;
+    const secondId = tabs.createTab("두번째");
+
+    const focusSpy = vi.spyOn(dom.editor, "focus");
+    const selectSpy = vi.spyOn(dom.editor, "setSelectionRange");
+
+    tabs.switchTab(firstId);
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+    expect(focusSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      selectSpy.mock.invocationCallOrder[0],
+    );
+    // switchTab 이 실제로 대상을 바꿨는지도 함께 확인 (secondId 는 더 이상 활성 아님)
+    expect(tabs.getActiveTab()!.id).toBe(firstId);
+    expect(secondId).not.toBe(firstId);
+  });
+
+  it("프리뷰 패널을 대상 탭 content 로 갱신한다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const firstId = tabs.getActiveTab()!.id;
+    tabs.createTab("# 제목");
+    tabs.switchTab(firstId);
+    tabs.switchTab(tabs.getAllTabs().find((t) => t.content === "# 제목")!.id);
+
+    expect(dom.preview.innerHTML).toContain("<h1");
+  });
+
+  it("존재하지 않는 id 면 아무 것도 하지 않는다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const before = tabs.getActiveTab()!.id;
+    tabs.switchTab("tab-does-not-exist");
+    expect(tabs.getActiveTab()!.id).toBe(before);
+  });
+});
+
+describe("closeTab", () => {
+  it("마지막 탭을 닫으면 새 Untitled 탭이 생성된다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const onlyId = tabs.getActiveTab()!.id;
+    tabs.closeTab(onlyId);
+
+    expect(tabs.getAllTabs()).toHaveLength(1);
+    const remaining = tabs.getActiveTab()!;
+    expect(remaining.id).not.toBe(onlyId);
+    expect(remaining.fileName).toBe(tabs.UNTITLED);
+  });
+
+  it("활성 탭을 닫으면 남은 탭 중 마지막 탭으로 전환된다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const firstId = tabs.getActiveTab()!.id;
+    const secondId = tabs.createTab("두번째");
+    const thirdId = tabs.createTab("세번째");
+    // 현재 활성 = thirdId. thirdId 를 닫으면 [firstId, secondId] 중 마지막(secondId)로 전환.
+    tabs.closeTab(thirdId);
+
+    expect(tabs.getAllTabs().map((t) => t.id)).toEqual([firstId, secondId]);
+    expect(tabs.getActiveTab()!.id).toBe(secondId);
+  });
+
+  it("비활성 탭을 닫으면 활성 탭은 그대로 유지된다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const firstId = tabs.getActiveTab()!.id;
+    const secondId = tabs.createTab("두번째");
+    // 활성 = secondId. 비활성인 firstId 를 닫는다.
+    tabs.closeTab(firstId);
+
+    expect(tabs.getAllTabs().map((t) => t.id)).toEqual([secondId]);
+    expect(tabs.getActiveTab()!.id).toBe(secondId);
+  });
+
+  it("존재하지 않는 id 면 아무 것도 하지 않는다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const before = tabs.getAllTabs().length;
+    tabs.closeTab("tab-nope");
+    expect(tabs.getAllTabs()).toHaveLength(before);
+  });
+});
+
+describe("closeTab dirty 확인", () => {
+  it("확인 콜백이 false 를 반환하면 닫히지 않는다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const id = tabs.getActiveTab()!.id;
+    tabs.markActiveTabDirty();
+
+    const confirmFn = vi.fn(() => false);
+    tabs.setCloseConfirm(confirmFn);
+
+    tabs.closeTab(id);
+
+    expect(confirmFn).toHaveBeenCalledTimes(1);
+    expect(tabs.getAllTabs().map((t) => t.id)).toEqual([id]);
+  });
+
+  it("확인 콜백이 true 를 반환하면 닫힌다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const id = tabs.getActiveTab()!.id;
+    tabs.markActiveTabDirty();
+
+    const confirmFn = vi.fn(() => true);
+    tabs.setCloseConfirm(confirmFn);
+
+    tabs.closeTab(id);
+
+    expect(confirmFn).toHaveBeenCalledTimes(1);
+    // 마지막 탭이었으므로 닫힌 뒤 새 Untitled 탭이 생겼을 것 — id 는 달라야 한다.
+    expect(tabs.getAllTabs().map((t) => t.id)).not.toEqual([id]);
+  });
+
+  it("확인 콜백을 등록하지 않으면 확인 없이 닫힌다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const id = tabs.getActiveTab()!.id;
+    tabs.markActiveTabDirty();
+    // setCloseConfirm 미호출
+
+    tabs.closeTab(id);
+
+    expect(tabs.getAllTabs().map((t) => t.id)).not.toEqual([id]);
+  });
+
+  it("dirty 가 아니면 확인 콜백을 호출하지 않는다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const id = tabs.getActiveTab()!.id;
+    const confirmFn = vi.fn(() => false);
+    tabs.setCloseConfirm(confirmFn);
+
+    tabs.closeTab(id);
+
+    expect(confirmFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("syncActiveTab", () => {
+  it("활성 탭에만 반영되고 비활성 탭은 영향받지 않는다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const firstId = tabs.getActiveTab()!.id;
+    // 아직 스냅샷되지 않은 첫 탭의 "진짜" 내용을 만들어 둔다.
+    tabs.createTab("두번째 원본"); // 활성 = second, 이 시점 switchTab 이 first 를 스냅샷(빈 문자열)
+
+    const secondId = tabs.getActiveTab()!.id;
+    dom.editor.value = "두번째 수정중 (아직 sync 안 됨)";
+
+    // sync 전에는 TabState.content 가 stale 하다.
+    expect(tabs.getAllTabs().find((t) => t.id === secondId)!.content).toBe(
+      "두번째 원본",
+    );
+
+    tabs.syncActiveTab();
+
+    expect(tabs.getAllTabs().find((t) => t.id === secondId)!.content).toBe(
+      "두번째 수정중 (아직 sync 안 됨)",
+    );
+    // 비활성 탭(first)은 무영향.
+    expect(tabs.getAllTabs().find((t) => t.id === firstId)!.content).toBe("");
+  });
+
+  it("활성 탭이 없으면 아무 동작도 하지 않는다 (throw 하지 않음)", async () => {
+    const tabs = await loadTabs();
+    expect(() => tabs.syncActiveTab()).not.toThrow();
+  });
+});
+
+describe("markActiveTabDirty", () => {
+  it("깨끗한 탭을 dirty 로 바꾸고 탭바를 다시 렌더링한다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    expect(tabs.getActiveTab()!.isDirty).toBe(false);
+    tabs.markActiveTabDirty();
+    expect(tabs.getActiveTab()!.isDirty).toBe(true);
+
+    const nameSpan = dom.tabBar.querySelector(".tab-name")!;
+    expect(nameSpan.textContent).toContain("*");
+  });
+
+  it("이미 dirty 면 재렌더링을 스킵한다 (no-op)", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    tabs.markActiveTabDirty();
+    const tabElBefore = dom.tabBar.querySelector(".tab")!;
+
+    tabs.markActiveTabDirty(); // 이미 dirty
+    const tabElAfter = dom.tabBar.querySelector(".tab")!;
+
+    // renderTabs() 는 tabBarEl.innerHTML = "" 후 재생성하므로, 다시 렌더링됐다면
+    // DOM 노드 참조가 바뀐다. no-op 이면 참조가 그대로다.
+    expect(tabElAfter).toBe(tabElBefore);
+  });
+});
+
+describe("restoreSession", () => {
+  it("저장된 세션을 그대로 복원한다", async () => {
+    const persisted: PersistedTab[] = [
+      { id: "tab-3", fileName: "a.md", content: "A", isDirty: false },
+      { id: "tab-7", fileName: "b.md", content: "B", isDirty: true },
+    ];
+    saveSession(createSession(persisted, "tab-7"));
+
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    expect(tabs.getAllTabs().map((t) => t.id)).toEqual(["tab-3", "tab-7"]);
+    expect(tabs.getActiveTab()!.id).toBe("tab-7");
+    expect(tabs.getActiveTab()!.isDirty).toBe(true);
+    expect(dom.editor.value).toBe("B");
+    // 복원된 탭은 handle 을 가질 수 없다.
+    expect(tabs.getAllTabs().every((t) => t.handle === null)).toBe(true);
+  });
+
+  it("ID 시퀀스가 복원된 최대값 뒤로 밀려 충돌을 막는다", async () => {
+    const persisted: PersistedTab[] = [
+      { id: "tab-2", fileName: "a.md", content: "A", isDirty: false },
+      { id: "tab-9", fileName: "b.md", content: "B", isDirty: false },
+    ];
+    saveSession(createSession(persisted, "tab-2"));
+
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const newId = tabs.createTab();
+    expect(newId).toBe("tab-10");
+  });
+
+  it("세션이 없으면 기본 Untitled 탭으로 시작한다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    expect(tabs.getAllTabs()).toHaveLength(1);
+    expect(tabs.getActiveTab()!.fileName).toBe(tabs.UNTITLED);
+    expect(tabs.getActiveTab()!.id).toBe("tab-1");
+  });
+
+  it("세션의 activeTabId 가 유효하지 않으면 첫 탭이 활성화된다", async () => {
+    const persisted: PersistedTab[] = [
+      { id: "tab-1", fileName: "a.md", content: "A", isDirty: false },
+    ];
+    saveSession(createSession(persisted, "tab-does-not-exist"));
+
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    expect(tabs.getActiveTab()!.id).toBe("tab-1");
+  });
+});
+
+describe("persistNow", () => {
+  it("성공하면 true 를 반환하고 활성 탭의 최신 본문(editorEl.value)을 저장한다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    dom.editor.value = "저장될 최신 내용";
+    const result = tabs.persistNow();
+
+    expect(result).toBe(true);
+    const { loadSession } = await import("../src/storage");
+    const loaded = loadSession();
+    expect(loaded!.tabs[0].content).toBe("저장될 최신 내용");
+  });
+
+  it("디바운스 타이머가 걸려 있어도 즉시 저장하고 타이머를 취소한다", async () => {
+    vi.useFakeTimers();
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    tabs.markActiveTabDirty(); // schedulePersist() 로 500ms 타이머 예약
+    const result = tabs.persistNow();
+    expect(result).toBe(true);
+
+    // 타이머가 취소됐으므로 이후 시간이 흘러도 추가 저장 호출에서 예외가 없어야 한다.
+    expect(() => vi.advanceTimersByTime(1000)).not.toThrow();
+  });
+});
+
+describe("findTabByHandle", () => {
+  it("isSameEntry() 로 일치하는 탭을 찾는다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const targetHandle = makeFakeHandle(() => true);
+    const otherHandle = makeFakeHandle(() => false);
+
+    tabs.updateActiveTab({ handle: otherHandle });
+    const secondId = tabs.createTab("두번째");
+    tabs.updateActiveTab({ handle: targetHandle });
+
+    const searchHandle = makeFakeHandle(() => false); // 실제 비교는 handle.isSameEntry 쪽에서 처리
+    const found = await tabs.findTabByHandle(searchHandle);
+
+    expect(found?.id).toBe(secondId);
+  });
+
+  it("일치하는 탭이 없으면 undefined 를 반환한다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    const handle = makeFakeHandle(() => false);
+    tabs.updateActiveTab({ handle });
+
+    const searchHandle = makeFakeHandle(() => false);
+    const found = await tabs.findTabByHandle(searchHandle);
+    expect(found).toBeUndefined();
+  });
+
+  it("handle 이 없는 탭은 건너뛴다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+    // handle 없는 기본 탭만 있는 상태.
+
+    const searchHandle = makeFakeHandle(() => true);
+    const found = await tabs.findTabByHandle(searchHandle);
+    expect(found).toBeUndefined();
+  });
+});
+
+describe("hasDirtyTabs / getActiveContent", () => {
+  it("dirty 탭이 하나도 없으면 false", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    expect(tabs.hasDirtyTabs()).toBe(false);
+  });
+
+  it("dirty 탭이 있으면 true", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    tabs.markActiveTabDirty();
+    expect(tabs.hasDirtyTabs()).toBe(true);
+  });
+
+  it("hasDirtyTabs 는 판정 전 활성 탭을 동기화한다", async () => {
+    const tabs = await loadTabs();
+    const dom = createDom();
+    tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+    tabs.markActiveTabDirty();
+    tabs.createTab("두번째"); // 첫 탭은 이제 비활성, dirty=true 로 스냅샷됨
+    dom.editor.value = "안 저장된 새 변경";
+
+    // getActiveContent() 는 항상 editorEl.value 그대로.
+    expect(tabs.getActiveContent()).toBe("안 저장된 새 변경");
+    expect(tabs.hasDirtyTabs()).toBe(true);
+  });
+});
+
+describe("용량 초과 알림", () => {
+  function stubQuotaExceeded() {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+    const backing = new Map<string, string>();
+    let fail = true;
+
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        get length() {
+          return backing.size;
+        },
+        clear: () => backing.clear(),
+        getItem: (k: string) => backing.get(k) ?? null,
+        key: (i: number) => [...backing.keys()][i] ?? null,
+        removeItem: (k: string) => backing.delete(k),
+        setItem: (k: string, v: string) => {
+          if (fail && k.startsWith("markdown-editor:session")) {
+            throw new DOMException("quota", "QuotaExceededError");
+          }
+          backing.set(k, v);
+        },
+      } satisfies Storage,
+    });
+
+    return {
+      setFail: (v: boolean) => {
+        fail = v;
+      },
+      restore: () => {
+        if (originalDescriptor) {
+          Object.defineProperty(window, "localStorage", originalDescriptor);
+        } else {
+          delete (window as { localStorage?: Storage }).localStorage;
+        }
+      },
+    };
+  }
+
+  it("저장 실패 시 1회만 알리고, 다시 성공하면 재알림 가능 상태로 돌아간다", async () => {
+    const stub = stubQuotaExceeded();
+    try {
+      const tabs = await loadTabs();
+      // tabs.ts 는 내부적으로 "./notice" 를 import 한다. vi.resetModules() 이후
+      // 같은 모듈 레지스트리에서 동적 import 해야 tabs.ts 가 실제로 쓰는
+      // notice 모듈 인스턴스(= containerEl 전역)를 공유할 수 있다. 정적 import
+      // 를 쓰면 리셋 이전의 별도 인스턴스를 잡아 showNotice 호출이 반영되지 않는다.
+      const { initNotice } = await import("../src/notice");
+      const dom = createDom();
+      initNotice(dom.notice);
+      tabs.initTabs(dom.tabBar, dom.editor, dom.preview, dom.title);
+
+      expect(tabs.persistNow()).toBe(false);
+      expect(dom.notice.hidden).toBe(false);
+      expect(dom.notice.textContent).toContain("저장 공간이 부족");
+
+      // 알림을 수동으로 닫아 둔 뒤 재실패시켜도 다시 뜨지 않아야 한다 (플래그).
+      dom.notice.hidden = true;
+      expect(tabs.persistNow()).toBe(false);
+      expect(dom.notice.hidden).toBe(true);
+
+      // 저장이 다시 성공하면 플래그가 풀린다.
+      stub.setFail(false);
+      expect(tabs.persistNow()).toBe(true);
+
+      // 다시 실패하면 알림이 재차 뜬다.
+      stub.setFail(true);
+      dom.notice.hidden = true;
+      expect(tabs.persistNow()).toBe(false);
+      expect(dom.notice.hidden).toBe(false);
+    } finally {
+      stub.restore();
+    }
+  });
+});


### PR DESCRIPTION
`Refs #16` — 로드맵 2단계. **`src/` 는 한 줄도 바꾸지 않았다.** 테스트만 추가했다.

## 목표 달성

| 지표 | 1단계 후 | 이번 | 목표 |
|------|----------|------|------|
| **All files Lines** | 30.45% | **60.15%** | 60% ✅ |
| `tabs.ts` | 6.97% | **97.67%** | |
| `notice.ts` | 0% | **100%** | |
| `editor.ts` · `shortcuts.ts` | 0% | 커버됨 | |

단위 테스트 **122건** (기존 66 + 신규 56).

## 왜 `tabs.ts` 가 최우선이었나

이 앱에서 **가장 중요한 상태 저장소**(333줄)인데 단위 안전망이 0% 였다. 고쳤을 때 무엇이 깨지는지 알려주는 게 E2E 뿐이라, 상태 로직을 손대는 리팩터링이 사실상 불가능했다.

## 동작 보존이 이 PR 의 핵심 제약

`src/tabs.ts` 는 **원본과 100% 동일**하다. 테스트하기 불편하다는 이유로 설계 규칙을 바꾸지 않았다.

| 지킨 규칙 | 왜 |
|-----------|-----|
| "활성 탭의 `content` 는 stale" (`data-model.md` §2.4) | `saveFile()` 이 이 규칙에 의존한다 |
| `switchTab` 의 `focus()` → `setSelectionRange()` 순서 | 뒤집으면 브라우저가 선택 영역을 되돌린다 (F-69 에서 실측) |
| `closeTab` 의 dirty 확인 콜백 구조 | |
| `persistNow(): boolean` 반환값 | `swUpdate.ts` 가 의존 |

## 커버한 영역

`createTab` / `switchTab`(스냅샷·복원·focus 순서) / `closeTab` **3분기**(마지막 탭·활성 탭·비활성 탭) / dirty 확인 콜백 / `syncActiveTab` / `markActiveTabDirty` no-op 가드 / `restoreSession` **ID 시퀀스 복구** / `persistNow` 반환값 / `findTabByHandle` / `hasDirtyTabs` / 용량 초과 알림 1회 제한

## 단언 검증 — 5종 버그 주입

이 세션에서 vacuous 단언을 겪은 뒤로 매번 확인한다. 프로덕션 코드에 **의도적 버그를 주입**해 대응 테스트가 실제로 실패하는지 봤다.

| 주입 | 결과 |
|------|------|
| `switchTab` 의 focus/selection 순서 역전 | ✅ FAIL |
| `restoreSession` 의 `nextId` 갱신 제거 | ✅ FAIL |
| `closeTab` 의 dirty 가드 제거 | ✅ FAIL |
| `markActiveTabDirty` 의 no-op 가드 제거 | ✅ FAIL |
| `persistNow` 의 `syncActiveTab` 제거 | ✅ FAIL |

전부 원복 확인.

## 남은 0%

| 파일 | 사유 |
|------|------|
| `toolbar.ts` | 1단계에서 계산 로직을 `textEdit.ts`(100%)로 뺐고, 남은 건 `execCommand`·`focus` 부수효과 껍데기와 버튼 정의 16개. E2E 16건이 이미 검증한다 |
| `main.ts` | 부트스트랩. E2E 가 전 경로를 지난다 |
| `fileOps.ts` 5.26% | 3단계 범위 (picker·Blob 모킹) |

## 검증

tsc 0 / 빌드 성공 / 단위 122건 / E2E dev 79 통과·15 skip / 프리뷰 swupdate 10건 — **회귀 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CtFxzJ9wgUjid5dDvZBNm