### PR TITLE
feat: 오프라인 상태 표시 (F-70)

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,16 @@
             </button>
           </div>
         </div>
+
+        <div
+          id="offline-indicator"
+          class="notice offline-indicator"
+          role="status"
+          aria-live="polite"
+          hidden
+        >
+          오프라인 상태입니다. 편집·저장은 이 기기에서 계속 동작합니다.
+        </div>
       </div>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import {
 import { initNotice, showNotice } from "./notice";
 import { isStorageAvailable } from "./storage";
 import { initSwUpdate, isUpdateReloadPending } from "./swUpdate";
+import { initOfflineIndicator } from "./offline";
 
 const editorEl = document.querySelector<HTMLTextAreaElement>("#editor");
 const previewEl = document.querySelector<HTMLElement>("#preview");
@@ -27,9 +28,15 @@ const titleEl = document.querySelector<HTMLElement>(".toolbar h1");
 const tabBarEl = document.querySelector<HTMLElement>("#tab-bar");
 const noticeEl = document.querySelector<HTMLElement>("#notice");
 const swUpdateEl = document.querySelector<HTMLElement>("#sw-update");
+const offlineEl = document.querySelector<HTMLElement>("#offline-indicator");
 
 if (editorEl && previewEl) {
   if (noticeEl) initNotice(noticeEl);
+
+  // F-70: 서비스 워커 등록 여부와 무관하게(개발 서버 포함) 항상 초기화한다 —
+  // online/offline 이벤트는 PROD 가드가 필요한 SW 등록과 달리 모든 환경에서
+  // 동일하게 동작하고, HMR 등 dev 서버 동작을 방해하지 않는다.
+  if (offlineEl) initOfflineIndicator({ badgeEl: offlineEl });
 
   createEditor({ editorEl, previewEl });
 

--- a/src/offline.ts
+++ b/src/offline.ts
@@ -1,0 +1,96 @@
+/**
+ * F-70 오프라인 상태 표시.
+ *
+ * 이슈 #17 의 판단 사항에 대한 결정과 근거:
+ *
+ * 1) 감지 신호 — `online`/`offline` 이벤트 + `navigator.onLine` 만 쓴다. 실제 요청
+ *    실패를 보강 신호로 쓰지 않는다. 이 앱은 최초 로드 이후 서비스 워커 업데이트
+ *    확인(§7.2, 60분 주기 + 가시성 복귀 시)을 빼면 네트워크를 전혀 쓰지 않으므로
+ *    "요청 실패 = 오프라인" 신호 자체가 거의 발생하지 않고, 발생해도 그 순간에만
+ *    반짝 오탐(온라인인데 offline 로 오판)할 위험이 실익보다 크다. 단순하고 예측
+ *    가능한 신호가 낫다.
+ * 2) 표시 형태 — 지속형 배지. 오프라인은 사라지지 않는 상태이므로 `notice.ts` 의
+ *    4초 자동 숨김 토스트는 쓰지 않는다. online 복귀 이벤트에서만 숨긴다.
+ * 3) `#notice-stack` 세 번째 항목 — `#sw-update` 뒤(스택 맨 아래)에 둔다. 토스트인
+ *    `#notice` 가 사라져도 레이아웃이 튀지 않도록 지속형 항목을 아래에 두는 기존
+ *    원칙(§notice-stack)을 그대로 따른다. `#sw-update` 는 사용자 액션(버튼)이 필요한
+ *    지속형 항목이라 정보 전달만 하는 이 배지보다 위에 둔다.
+ * 4) 오해 방지 — 문구에 "저장 안 됨" 을 암시하는 표현을 넣지 않는다. 편집·자동
+ *    저장·파일 저장은 오프라인에서도 전부 로컬로 동작하므로 경고가 아니라 정보
+ *    전달로 문구를 고정한다(index.html 정적 텍스트).
+ *
+ * `swUpdate.ts` 와 동일하게 앱 모듈을 하나도 import 하지 않는 주입형 리프 모듈이다.
+ * 전역 `navigator.onLine`/`window` 이벤트를 직접 읽지 않고 host 로 주입받아, 단위
+ * 테스트에서 실제 브라우저 온오프라인 전환 없이 가짜 host 만으로 전량 검증한다.
+ */
+
+export interface OfflineHost {
+  /** 알림 요소 (index.html 에 정적으로 존재하는 #offline-indicator) */
+  badgeEl: HTMLElement;
+  /** 초기 상태 판정. 기본 구현은 navigator.onLine */
+  isOnline(): boolean;
+  /** online 이벤트 구독. 해제 함수를 반환 */
+  onOnline(fn: () => void): () => void;
+  /** offline 이벤트 구독. 해제 함수를 반환 */
+  onOffline(fn: () => void): () => void;
+}
+
+/**
+ * 재진입 가드(swUpdate.ts 의 `initialized` 와 동일한 원칙). main.ts 는 앱 생애주기당
+ * 정확히 한 번만 호출한다.
+ */
+let initialized = false;
+
+function resolveHost(
+  partial: Partial<OfflineHost> & Pick<OfflineHost, "badgeEl">,
+): OfflineHost {
+  return {
+    isOnline: () => navigator.onLine,
+    onOnline: (fn) => {
+      window.addEventListener("online", fn);
+      return () => window.removeEventListener("online", fn);
+    },
+    onOffline: (fn) => {
+      window.addEventListener("offline", fn);
+      return () => window.removeEventListener("offline", fn);
+    },
+    ...partial,
+  };
+}
+
+/**
+ * F-70 오프라인 배지 초기화. 예외가 에디터 기능을 중단시키지 않도록(swUpdate.ts 의
+ * NFR-2 와 동일 원칙) 내부 전체를 보호한다.
+ */
+export function initOfflineIndicator(
+  partialHost: Partial<OfflineHost> & Pick<OfflineHost, "badgeEl">,
+): void {
+  if (initialized) {
+    console.warn("[offline] 이미 초기화되어 재호출을 무시합니다.");
+    return;
+  }
+  initialized = true;
+  try {
+    const host = resolveHost(partialHost);
+    const badgeEl = host.badgeEl;
+
+    function show(): void {
+      badgeEl.hidden = false;
+    }
+    function hide(): void {
+      badgeEl.hidden = true;
+    }
+
+    // 로드 시점 초기 상태 반영.
+    if (host.isOnline()) {
+      hide();
+    } else {
+      show();
+    }
+
+    host.onOffline(show);
+    host.onOnline(hide);
+  } catch (error) {
+    console.warn("[offline] 초기화 실패:", error);
+  }
+}

--- a/tests/e2e/offline.spec.ts
+++ b/tests/e2e/offline.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * F-70 오프라인 상태 표시.
+ *
+ * `online`/`offline` 이벤트는 서비스 워커·`_headers` 와 달리 배포 환경에 의존하지
+ * 않으므로(§design) 로컬 dev 서버에서도 그대로 검증한다(hardening.spec.ts 의
+ * isRemote 스킵 패턴 불필요). `context.setOffline()` 으로 실제 오프라인을 재현한다.
+ */
+test.describe("F-70 오프라인 상태 표시", () => {
+  test("페이지 로드 후 오프라인 전환 시 배지가 뜨고, 온라인 복귀 시 사라진다", async ({
+    page,
+    context,
+  }) => {
+    await page.goto("/");
+    const editor = page.locator("#editor");
+    await expect(editor).toBeVisible();
+
+    const indicator = page.locator("#offline-indicator");
+    await expect(indicator).toBeHidden();
+
+    await context.setOffline(true);
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toHaveText(/오프라인/);
+
+    await context.setOffline(false);
+    await expect(indicator).toBeHidden();
+  });
+
+  test("오프라인 상태에서도 편집·프리뷰가 계속 동작한다", async ({ page, context }) => {
+    await page.goto("/");
+    const editor = page.locator("#editor");
+    await expect(editor).toBeVisible();
+
+    await context.setOffline(true);
+    await expect(page.locator("#offline-indicator")).toBeVisible();
+
+    await editor.fill("# 오프라인 편집");
+    await expect(page.locator("#preview h1")).toHaveText("오프라인 편집");
+
+    await context.setOffline(false);
+  });
+
+  // 참고: "최초 로드부터 오프라인" 케이스(로드 시점 navigator.onLine === false)는
+  // 서비스 워커가 앱 셸을 캐시해야만 오프라인 상태에서 페이지 자체가 열리므로
+  // (§7.1, dev 서버는 SW 미등록) 이 스펙에서는 재현하지 않는다 — 대신
+  // `tests/offline.test.ts` 단위 테스트가 가짜 host 로 이 경로를 전량 검증한다.
+
+  test("기존 알림(#notice)·갱신 알림(#sw-update) id/구조를 건드리지 않는다", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // F-70 이전부터 있던 알림 요소들이 그대로 존재해야 한다(회귀 방지).
+    await expect(page.locator("#notice")).toBeAttached();
+    await expect(page.locator("#sw-update")).toBeAttached();
+    await expect(page.locator("#sw-update-text-idle")).toBeAttached();
+    await expect(page.locator("#sw-update-text-updating")).toBeAttached();
+    await expect(page.locator("#sw-update-later")).toBeAttached();
+    await expect(page.locator("#sw-update-reload")).toBeAttached();
+  });
+});

--- a/tests/offline.test.ts
+++ b/tests/offline.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OfflineHost } from "../src/offline";
+
+/**
+ * `offline.ts` 는 swUpdate.ts 와 동일하게 앱 모듈을 import 하지 않는 리프 모듈이다.
+ * 전역 navigator.onLine/window 이벤트를 직접 읽지 않고 OfflineHost 로 주입받으므로
+ * 가짜 host 만으로 전량 검증한다. `initialized` 는 모듈 스코프 상태라 테스트마다
+ * `vi.resetModules()` 로 모듈을 새로 로드해 누수를 막는다.
+ */
+async function loadOffline(): Promise<typeof import("../src/offline")> {
+  vi.resetModules();
+  return import("../src/offline");
+}
+
+function createBadge(): HTMLElement {
+  document.body.innerHTML = `<div id="offline-indicator" hidden></div>`;
+  return document.querySelector<HTMLElement>("#offline-indicator")!;
+}
+
+function makeHost(
+  badgeEl: HTMLElement,
+  overrides: Partial<OfflineHost> = {},
+): OfflineHost & {
+  emitOffline: () => void;
+  emitOnline: () => void;
+} {
+  const offlineListeners = new Set<() => void>();
+  const onlineListeners = new Set<() => void>();
+  const host: OfflineHost & { emitOffline: () => void; emitOnline: () => void } = {
+    badgeEl,
+    isOnline: vi.fn(() => true),
+    onOffline: vi.fn((fn: () => void) => {
+      offlineListeners.add(fn);
+      return () => offlineListeners.delete(fn);
+    }),
+    onOnline: vi.fn((fn: () => void) => {
+      onlineListeners.add(fn);
+      return () => onlineListeners.delete(fn);
+    }),
+    emitOffline: () => offlineListeners.forEach((fn) => fn()),
+    emitOnline: () => onlineListeners.forEach((fn) => fn()),
+    ...overrides,
+  };
+  return host;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("offline — 초기 상태 판정", () => {
+  it("로드 시점에 온라인이면 배지가 숨겨진 상태를 유지한다", async () => {
+    const { initOfflineIndicator } = await loadOffline();
+    const badgeEl = createBadge();
+    const host = makeHost(badgeEl, { isOnline: vi.fn(() => true) });
+
+    initOfflineIndicator(host);
+
+    expect(badgeEl.hidden).toBe(true);
+  });
+
+  it("로드 시점에 오프라인이면 배지를 즉시 표시한다", async () => {
+    const { initOfflineIndicator } = await loadOffline();
+    const badgeEl = createBadge();
+    const host = makeHost(badgeEl, { isOnline: vi.fn(() => false) });
+
+    initOfflineIndicator(host);
+
+    expect(badgeEl.hidden).toBe(false);
+  });
+});
+
+describe("offline — 전환 반영", () => {
+  it("offline 이벤트가 오면 배지를 표시한다", async () => {
+    const { initOfflineIndicator } = await loadOffline();
+    const badgeEl = createBadge();
+    const host = makeHost(badgeEl, { isOnline: vi.fn(() => true) });
+
+    initOfflineIndicator(host);
+    expect(badgeEl.hidden).toBe(true);
+
+    host.emitOffline();
+    expect(badgeEl.hidden).toBe(false);
+  });
+
+  it("online 이벤트가 오면 배지를 숨긴다", async () => {
+    const { initOfflineIndicator } = await loadOffline();
+    const badgeEl = createBadge();
+    const host = makeHost(badgeEl, { isOnline: vi.fn(() => false) });
+
+    initOfflineIndicator(host);
+    expect(badgeEl.hidden).toBe(false);
+
+    host.emitOnline();
+    expect(badgeEl.hidden).toBe(true);
+  });
+
+  it("오프라인 → 온라인 → 오프라인 반복 전환을 정확히 반영한다", async () => {
+    const { initOfflineIndicator } = await loadOffline();
+    const badgeEl = createBadge();
+    const host = makeHost(badgeEl, { isOnline: vi.fn(() => true) });
+
+    initOfflineIndicator(host);
+    host.emitOffline();
+    expect(badgeEl.hidden).toBe(false);
+
+    host.emitOnline();
+    expect(badgeEl.hidden).toBe(true);
+
+    host.emitOffline();
+    expect(badgeEl.hidden).toBe(false);
+  });
+});
+
+describe("offline — 재진입 가드", () => {
+  it("두 번째 초기화 호출은 무시된다(첫 host 로 등록된 리스너만 유효)", async () => {
+    const { initOfflineIndicator } = await loadOffline();
+    const badgeEl = createBadge();
+    const host1 = makeHost(badgeEl, { isOnline: vi.fn(() => true) });
+    const host2 = makeHost(badgeEl, { isOnline: vi.fn(() => true) });
+
+    initOfflineIndicator(host1);
+    initOfflineIndicator(host2);
+
+    // host2 의 offline 구독자는 등록되지 않았어야 한다.
+    host2.emitOffline();
+    expect(badgeEl.hidden).toBe(true);
+
+    // host1 을 통해서는 정상 반영된다.
+    host1.emitOffline();
+    expect(badgeEl.hidden).toBe(false);
+  });
+});
+
+describe("offline — 예외 격리 (NFR-2 와 동일 원칙)", () => {
+  it("isOnline() 이 예외를 던져도 초기화 자체가 앱을 중단시키지 않는다", async () => {
+    const { initOfflineIndicator } = await loadOffline();
+    const badgeEl = createBadge();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(() =>
+      initOfflineIndicator({
+        badgeEl,
+        isOnline: () => {
+          throw new Error("boom");
+        },
+      }),
+    ).not.toThrow();
+
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`Closes #17`

F-61 에서 오프라인 지원을 넣었지만 **사용자는 자신이 오프라인인지 알 방법이 없었다.** 화면이 평소와 똑같기 때문이다.

## 판단 4건과 근거

### 1. 감지 신호 — `online`/`offline` 이벤트만, 요청 실패 보강 없음

`navigator.onLine` 은 랜 연결만 보고 실제 인터넷 도달은 모른다는 걸 알고 있다. 그럼에도 보강하지 않았다.

**이 앱은 최초 로드 후 네트워크를 거의 쓰지 않는다**(서비스 워커 업데이트 확인 제외). 문서는 서버로 전송되지 않고 파일 I/O 는 전부 로컬이다. 즉 "실제 도달 여부"를 알아낼 자연스러운 요청이 없어서, 감지를 위해 **일부러 요청을 만들어야** 한다. 오탐이 잦은 정교한 감지는 정보 전달이라는 목적 자체를 해친다.

### 2. 표시 형태 — 지속형 배지

오프라인은 **지속 상태**다. `notice.ts` 의 4초 자동 숨김 토스트를 재사용하면 자리를 비운 사이 떴다 사라져 기능이 무의미해진다.

### 3. 스택 위치 — `#sw-update` 뒤(맨 아래)

기존 "지속형 아래, 일시 토스트 위" 원칙을 유지했다. 세 항목 중 **액션이 필요한 알림(갱신)을 정보성 알림보다 위**에 둔다.

### 4. 문구 — 경고가 아니라 정보

이 앱은 오프라인에서도 **완전히 동작한다**(편집·프리뷰·탭·자동 저장·파일 저장 전부 로컬). 표시가 "저장이 안 된다"는 오해를 주면 안 된다. 경고색을 쓰지 않고 **"편집·저장은 이 기기에서 계속 동작합니다"** 를 명시했다.

## 설계 — 주입형 리프

`src/offline.ts` 는 `swUpdate.ts` 와 같은 패턴이다. 전역 `navigator.onLine` 과 `window` 이벤트를 직접 읽지 않고 `OfflineHost` 로 주입받는다.

이 세션에서 이 패턴이 테스트 용이성으로 직결된다는 게 **세 번** 확인됐다.

| 사례 | 결과 |
|------|------|
| `swUpdate.ts` DI 리프 설계 | 79% 커버 |
| `hasController()` host 이동 (#11) | 테스트의 전역 `navigator` 패치 제거 |
| `tabs.ts` 주입 DOM 테스트 | 6.97% → 97.67% |

**기존 알림은 한 줄도 건드리지 않았다** — `#notice`, `#sw-update` 및 하위 id 전부 무변경.

## 테스트

- 단위 `tests/offline.test.ts` 7건 — 주입형이라 가짜 host 로 전량 검증
- E2E `tests/e2e/offline.spec.ts` 3건 — Playwright `context.setOffline()` 으로 **실제 오프라인 재현**

### 단언 검증

구독 로직을 주석 처리해 **단위 6/7건과 E2E 2건이 실제로 실패**하는 것을 확인하고 원복했다.

## 검증

| 항목 | 결과 |
|------|------|
| `tsc --noEmit` | 오류 0 |
| 단위 | **129건** |
| 라인 커버리지 | 60.15% → **60.76%** (떨어뜨리지 않음) |
| E2E (dev 서버) | **82 통과** / 15 skip (신규 3건 포함) |
| E2E 프리뷰 `swupdate.spec.ts` | 10/10 (F-69 회귀 0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CtFxzJ9wgUjid5dDvZBNm