### PR TITLE
feat: 브라우저별 기능 한계 안내 (F-58)

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,25 @@
         <div id="notice" class="notice" role="status" aria-live="polite" hidden></div>
 
         <div
+          id="fs-limit-notice"
+          class="notice fs-limit-notice"
+          role="status"
+          aria-live="polite"
+          hidden
+        >
+          <p class="sw-update-text">
+            이 브라우저에서는 파일을 직접 덮어쓸 수 없어 저장할 때마다 새 파일이
+            다운로드 폴더에 추가됩니다.<br />최신 내용은 다운로드 폴더에서
+            확인하세요. Chrome·Edge에서는 원본에 바로 저장됩니다.
+          </p>
+          <div class="sw-update-actions">
+            <button type="button" id="fs-limit-notice-dismiss" class="sw-update-btn">
+              확인
+            </button>
+          </div>
+        </div>
+
+        <div
           id="sw-update"
           class="notice sw-update"
           role="status"

--- a/src/fileOps.ts
+++ b/src/fileOps.ts
@@ -10,6 +10,7 @@ import {
   updateActiveTab,
 } from "./tabs";
 import { showNotice } from "./notice";
+import { notifyFallbackSave } from "./fsLimitNotice";
 
 /**
  * 브라우저 파일 I/O.
@@ -140,6 +141,9 @@ export async function saveFileAs(): Promise<void> {
   const suggestedName = suggestFileName(tab.fileName);
 
   if (!isFileSystemAccessSupported()) {
+    // F-58: 저장을 실제로 실행하는 이 시점에 브라우저 한계를 안내한다(세션당 1회).
+    // 저장 동작 자체(다운로드 방식·파일명·성공 알림)는 그대로 두고 부가 안내만 더한다.
+    notifyFallbackSave();
     downloadFile(content, suggestedName);
     updateActiveTab({ fileName: suggestedName, isDirty: false });
     showNotice(`${suggestedName} 을(를) 내려받았습니다.`);

--- a/src/fsLimitNotice.ts
+++ b/src/fsLimitNotice.ts
@@ -1,0 +1,123 @@
+/**
+ * F-58 브라우저별 기능 한계 안내.
+ *
+ * 이슈 #25 의 판단 사항에 대한 결정과 근거:
+ *
+ * 1) 표시 시점 — 폴백(Safari·Firefox) 모드에서 사용자가 **처음 저장을 시도하는
+ *    순간** 1회만 보여준다(세션당 1회, 모듈 스코프 `shown` 플래그로 이후 호출을
+ *    무시한다). 앱 진입 시 띄우면 아직 문제와 무관한 시점이라 무시되기 쉽고 다음
+ *    실제 저장 때는 기억나지 않는다. 상시 배지는 편집 내내 화면을 차지해 "반복
+ *    소음"이 된다(이슈가 명시한 우려). 저장을 실행하는 시점에 맞춰 보여주면
+ *    "note (1).md 가 왜 생겼지?" 하고 당황하기 전에 원인을 먼저 알 수 있다.
+ * 2) 중복 열기 제약 — 별도로 알리지 않는다. 저장(데이터가 예상과 다른 곳에
+ *    쌓임)보다 체감 손실이 작고(탭이 하나 더 생길 뿐 데이터 유실은 없다), 별도
+ *    알림을 추가하면 세션당 알림이 2개로 늘어 소음만 커진다. 저장 안내 문구가
+ *    이미 "이 브라우저는 파일 핸들을 다룰 수 없다"는 같은 근본 원인을 설명하므로
+ *    충분하다고 판단했다.
+ * 3) 알림 스택 — 기존 `showNotice()`(`#notice`)를 재사용하지 않고 새 스택 항목을
+ *    추가했다. `saveFileAs()` 는 같은 타이밍에 "OO 을(를) 내려받았습니다" 토스트를
+ *    이미 `#notice` 에 띄우므로, 같은 요소에 다시 쓰면 먼저 뜬 메시지를 지우거나
+ *    (showNotice 는 내용과 타이머를 덮어쓴다) 두 메시지의 순서가 꼬인다. `.notice-stack`
+ *    은 이미 `max-width: min(420px, calc(100% - 32px))` 로 좁은 화면(720px 이하
+ *    포함)에 대응하므로 네 번째 항목을 더해도 폭 문제는 없다. 세션당 1회만 뜨고
+ *    자동 숨김 타이머 없이 수동으로만 닫힌다 — offline.ts 의 "토스트는 자리를 비운
+ *    사이 사라져 무의미해진다" 원칙과 같은 이유로, 안내를 읽기 전에 사라지면 목적을
+ *    잃는다. DOM 순서는 `#notice`(가장 빈번한 일시 토스트) 바로 다음, `#sw-update`
+ *    /`#offline-indicator`(지속형) 이전에 둔다 — "지속형 아래, 일시 위" 원칙
+ *    (style.css `.notice-stack` 주석)을 그대로 따른다.
+ * 4) 문구 — 비난조("당신 브라우저는 못 합니다")를 피하고 "이 브라우저에서는 이렇게
+ *    동작한다"는 사실과 사용자가 할 일("다운로드 폴더에서 최신 내용 확인")을 함께
+ *    전달한다. Chrome·Edge 로 전환하면 해결된다는 대안도 담아 행동 지침을 준다.
+ *
+ * `offline.ts`/`swUpdate.ts` 와 동일한 주입형 리프 모듈이다 — 앱 모듈을 하나도
+ * import 하지 않는다. 표시 여부를 가르는 폴백 판정(`isFileSystemAccessSupported()`)도
+ * 이 모듈이 직접 읽지 않고 호출자가 판단해 `initFsLimitNotice()` 호출 여부로 넘긴다.
+ * Chrome·Edge 에서는 아예 초기화되지 않으므로 리스너조차 붙지 않아 "아무것도 보이지
+ * 않아야 한다"는 요구를 가장 확실하게 만족한다.
+ */
+
+export interface FsLimitNoticeHost {
+  /** 알림 요소 (index.html 에 정적으로 존재하는 #fs-limit-notice) */
+  panelEl: HTMLElement;
+  /** "확인" 클릭 후 포커스를 되돌릴 요소 */
+  returnFocusTo?: HTMLElement | null;
+}
+
+/** 재진입 가드 — swUpdate.ts/offline.ts 와 동일 원칙. */
+let initialized = false;
+/** 세션당 1회 표시 가드(판단 1). dismiss 여부와 무관하게 "이미 보여준 적 있음"을 기록한다. */
+let shown = false;
+
+let panelEl: HTMLElement | null = null;
+let returnFocusTo: HTMLElement | null = null;
+
+function resolveHost(
+  partial: Partial<FsLimitNoticeHost> & Pick<FsLimitNoticeHost, "panelEl">,
+): FsLimitNoticeHost {
+  return { returnFocusTo: null, ...partial };
+}
+
+/**
+ * 닫기 버튼·Esc 배선을 준비한다. 호출자(main.ts)는 폴백 모드일 때만 이 함수를
+ * 부른다 — 지원 브라우저에서는 호출 자체를 생략해 리스너가 하나도 붙지 않는다.
+ *
+ * 예외가 에디터 기능을 중단시키지 않도록(swUpdate.ts 의 NFR-2 와 동일 원칙) 내부
+ * 전체를 보호한다.
+ */
+export function initFsLimitNotice(
+  partialHost: Partial<FsLimitNoticeHost> & Pick<FsLimitNoticeHost, "panelEl">,
+): void {
+  if (initialized) {
+    console.warn("[fs-limit-notice] 이미 초기화되어 재호출을 무시합니다.");
+    return;
+  }
+  initialized = true;
+  try {
+    const host = resolveHost(partialHost);
+    panelEl = host.panelEl;
+    returnFocusTo = host.returnFocusTo ?? null;
+
+    const dismissBtn = panelEl.querySelector<HTMLButtonElement>(
+      "#fs-limit-notice-dismiss",
+    );
+
+    function hide(): void {
+      if (panelEl) panelEl.hidden = true;
+    }
+
+    function handleDismiss(): void {
+      returnFocusTo?.focus();
+      hide();
+    }
+
+    dismissBtn?.addEventListener("click", handleDismiss);
+
+    // Esc 는 알림 내부에 포커스가 있을 때만 닫기로 동작한다(swUpdate.ts 와 동일).
+    // document 전역 리스너를 쓰면 shortcuts.ts 와 충돌한다.
+    panelEl.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        handleDismiss();
+      }
+    });
+  } catch (error) {
+    console.warn("[fs-limit-notice] 초기화 실패:", error);
+  }
+}
+
+/**
+ * 폴백 모드에서 사용자가 저장을 시도한 시점에 호출한다(fileOps.ts `saveFileAs()`
+ * 의 폴백 분기). 세션당 1회만 실제로 표시하고, 이후 호출은 조용히 무시한다
+ * (판단 1 — 반복 소음 방지). `initFsLimitNotice()` 가 호출되지 않았다면(예: 아직
+ * 배선 전이거나 지원 브라우저) 아무 일도 하지 않는다.
+ */
+export function notifyFallbackSave(): void {
+  if (shown) return;
+  if (!panelEl) return;
+  shown = true;
+  try {
+    panelEl.hidden = false;
+  } catch (error) {
+    console.warn("[fs-limit-notice] 표시 실패:", error);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { initNotice, showNotice } from "./notice";
 import { isStorageAvailable } from "./storage";
 import { initSwUpdate, isUpdateReloadPending } from "./swUpdate";
 import { initOfflineIndicator } from "./offline";
+import { initFsLimitNotice } from "./fsLimitNotice";
 
 const editorEl = document.querySelector<HTMLTextAreaElement>("#editor");
 const previewEl = document.querySelector<HTMLElement>("#preview");
@@ -29,6 +30,7 @@ const tabBarEl = document.querySelector<HTMLElement>("#tab-bar");
 const noticeEl = document.querySelector<HTMLElement>("#notice");
 const swUpdateEl = document.querySelector<HTMLElement>("#sw-update");
 const offlineEl = document.querySelector<HTMLElement>("#offline-indicator");
+const fsLimitNoticeEl = document.querySelector<HTMLElement>("#fs-limit-notice");
 
 if (editorEl && previewEl) {
   if (noticeEl) initNotice(noticeEl);
@@ -80,7 +82,15 @@ if (editorEl && previewEl) {
     if (document.visibilityState === "hidden") persistNow();
   });
 
-  document.body.dataset.fsAccess = String(isFileSystemAccessSupported());
+  const fsAccessSupported = isFileSystemAccessSupported();
+  document.body.dataset.fsAccess = String(fsAccessSupported);
+
+  // F-58: Chrome·Edge 에는 아무것도 보이면 안 되므로, 폴백 모드일 때만 초기화한다.
+  // 호출 자체를 생략하는 편이 리스너 유무까지 포함해 "아무것도 안 뜬다"를 가장
+  // 확실하게 보장한다(§fsLimitNotice.ts 판단 근거).
+  if (fsLimitNoticeEl && !fsAccessSupported) {
+    initFsLimitNotice({ panelEl: fsLimitNoticeEl, returnFocusTo: editorEl });
+  }
 
   // 서비스 워커는 프로덕션 빌드에서만 등록한다. 개발 서버에서 등록하면 HMR 결과가
   // 캐시에 가려 "고쳤는데 안 바뀌는" 상황을 만든다.

--- a/tests/e2e/fileaccess.spec.ts
+++ b/tests/e2e/fileaccess.spec.ts
@@ -179,3 +179,86 @@ test.describe("폴백 경로 (Safari·Firefox)", () => {
     expect(download.suggestedFilename()).toBe("note.md");
   });
 });
+
+test.describe("F-58 브라우저별 기능 한계 안내 (폴백 경로 전용)", () => {
+  test.beforeEach(async ({ page }) => {
+    await installFallbackMode(page);
+    await page.goto("/");
+    await expect(page.locator("#editor")).toBeVisible();
+  });
+
+  test("앱 진입 직후에는 안내가 뜨지 않는다 — 저장을 시도할 때까지는 조용하다", async ({
+    page,
+  }) => {
+    await expect(page.locator("#fs-limit-notice")).toBeHidden();
+  });
+
+  test("첫 저장 시도에 브라우저 한계를 안내한다", async ({ page }) => {
+    await page.locator("#editor").fill("내려받을 내용");
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.keyboard.press("ControlOrMeta+s");
+    await downloadPromise;
+
+    const notice = page.locator("#fs-limit-notice");
+    await expect(notice).toBeVisible();
+    await expect(notice).toContainText("덮어쓸 수 없어");
+    // 저장 성공 토스트(#notice)도 그대로 뜬다 — 서로 다른 요소라 겹쳐 써지지 않는다.
+    await expect(page.locator("#notice")).toContainText("내려받았습니다");
+  });
+
+  test("두 번째 저장부터는 다시 뜨지 않는다(세션당 1회)", async ({ page }) => {
+    await page.locator("#editor").fill("첫 번째 저장");
+    const firstDownload = page.waitForEvent("download");
+    await page.keyboard.press("ControlOrMeta+s");
+    await firstDownload;
+
+    await page
+      .locator("#fs-limit-notice-dismiss")
+      .click();
+    await expect(page.locator("#fs-limit-notice")).toBeHidden();
+
+    await page.locator("#editor").fill("두 번째 저장");
+    const secondDownload = page.waitForEvent("download");
+    await page.keyboard.press("ControlOrMeta+s");
+    await secondDownload;
+
+    await expect(page.locator("#fs-limit-notice")).toBeHidden();
+  });
+
+  test("확인 버튼으로 안내를 닫을 수 있다", async ({ page }) => {
+    await page.locator("#editor").fill("내용");
+    const downloadPromise = page.waitForEvent("download");
+    await page.keyboard.press("ControlOrMeta+s");
+    await downloadPromise;
+
+    const notice = page.locator("#fs-limit-notice");
+    await expect(notice).toBeVisible();
+
+    await page.locator("#fs-limit-notice-dismiss").click();
+    await expect(notice).toBeHidden();
+  });
+});
+
+test.describe("F-58 — Chrome·Edge 경로에서는 안 보인다", () => {
+  test.beforeEach(async ({ page }) => {
+    await installFsMock(page);
+    await page.goto("/");
+    await expect(page.locator("#editor")).toBeVisible();
+  });
+
+  test("File System Access API 지원 브라우저에서는 저장해도 안내가 뜨지 않는다", async ({
+    page,
+  }) => {
+    await setFsMock(page, { saveName: "새문서.md" });
+    await page.locator("#editor").fill("# 새 문서");
+    await page.keyboard.press("ControlOrMeta+s");
+
+    await expect.poll(() => getWrites(page)).toEqual([
+      { name: "새문서.md", content: "# 새 문서" },
+    ]);
+    await expect(page.locator("#fs-limit-notice")).toBeHidden();
+    // DOM 에 아예 표시되지 않아야 한다는 요구를 강하게 검증한다 — hidden 속성 유지 확인.
+    await expect(page.locator("#fs-limit-notice")).toHaveAttribute("hidden", "");
+  });
+});

--- a/tests/fsLimitNotice.test.ts
+++ b/tests/fsLimitNotice.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FsLimitNoticeHost } from "../src/fsLimitNotice";
+
+/**
+ * `fsLimitNotice.ts` 는 offline.ts/swUpdate.ts 와 동일하게 앱 모듈을 import 하지
+ * 않는 리프 모듈이다. DOM 요소만 주입받아 가짜 host 로 전량 검증한다. `initialized`
+ * ·`shown` 은 모듈 스코프 상태라 테스트 간 누수를 막기 위해 매 테스트마다
+ * `vi.resetModules()` 로 모듈을 새로 로드한다.
+ */
+async function loadFsLimitNotice(): Promise<typeof import("../src/fsLimitNotice")> {
+  vi.resetModules();
+  return import("../src/fsLimitNotice");
+}
+
+function createPanel(): HTMLElement {
+  document.body.innerHTML = `
+    <div id="fs-limit-notice" hidden>
+      <button type="button" id="fs-limit-notice-dismiss"></button>
+    </div>
+  `;
+  return document.querySelector<HTMLElement>("#fs-limit-notice")!;
+}
+
+function makeHost(
+  panelEl: HTMLElement,
+  overrides: Partial<FsLimitNoticeHost> = {},
+): FsLimitNoticeHost {
+  return { panelEl, returnFocusTo: null, ...overrides };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fsLimitNotice — 트리거 전에는 아무 일도 하지 않는다", () => {
+  it("init 하지 않고 notifyFallbackSave() 를 불러도 표시되지 않는다", async () => {
+    const { notifyFallbackSave } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+
+    notifyFallbackSave();
+
+    expect(panelEl.hidden).toBe(true);
+  });
+
+  it("init 직후에는 아직 표시되지 않는다(트리거 전)", async () => {
+    const { initFsLimitNotice } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+
+    initFsLimitNotice(makeHost(panelEl));
+
+    expect(panelEl.hidden).toBe(true);
+  });
+});
+
+describe("fsLimitNotice — 저장 시도 시 표시(판단 1: 첫 저장 시점)", () => {
+  it("notifyFallbackSave() 호출 시 알림을 표시한다", async () => {
+    const { initFsLimitNotice, notifyFallbackSave } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+    initFsLimitNotice(makeHost(panelEl));
+
+    notifyFallbackSave();
+
+    expect(panelEl.hidden).toBe(false);
+  });
+
+  it("세션당 1회만 표시한다 — 두 번째 저장 시도에는 이미 닫은 알림을 다시 열지 않는다", async () => {
+    const { initFsLimitNotice, notifyFallbackSave } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+    initFsLimitNotice(makeHost(panelEl));
+
+    notifyFallbackSave();
+    expect(panelEl.hidden).toBe(false);
+
+    panelEl.hidden = true; // 사용자가 확인을 눌러 닫았다고 가정
+    notifyFallbackSave(); // 두 번째 저장 시도
+
+    expect(panelEl.hidden).toBe(true);
+  });
+});
+
+describe("fsLimitNotice — 닫기 동작", () => {
+  it("확인 버튼 클릭 시 알림을 숨기고 포커스를 되돌린다", async () => {
+    const { initFsLimitNotice, notifyFallbackSave } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+    const returnFocusTo = document.createElement("textarea");
+    document.body.appendChild(returnFocusTo);
+    const focusSpy = vi.spyOn(returnFocusTo, "focus");
+
+    initFsLimitNotice(makeHost(panelEl, { returnFocusTo }));
+    notifyFallbackSave();
+    expect(panelEl.hidden).toBe(false);
+
+    panelEl.querySelector<HTMLButtonElement>("#fs-limit-notice-dismiss")!.click();
+
+    expect(panelEl.hidden).toBe(true);
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("Esc 키 입력 시 알림을 숨긴다", async () => {
+    const { initFsLimitNotice, notifyFallbackSave } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+    initFsLimitNotice(makeHost(panelEl));
+    notifyFallbackSave();
+    expect(panelEl.hidden).toBe(false);
+
+    panelEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect(panelEl.hidden).toBe(true);
+  });
+
+  it("Esc 이외의 키 입력은 무시한다", async () => {
+    const { initFsLimitNotice, notifyFallbackSave } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+    initFsLimitNotice(makeHost(panelEl));
+    notifyFallbackSave();
+
+    panelEl.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect(panelEl.hidden).toBe(false);
+  });
+});
+
+describe("fsLimitNotice — 재진입 가드", () => {
+  it("두 번째 초기화 호출은 무시된다(첫 host 로 등록된 리스너만 유효)", async () => {
+    const { initFsLimitNotice, notifyFallbackSave } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+    const returnFocusTo1 = document.createElement("textarea");
+    const returnFocusTo2 = document.createElement("textarea");
+    const focus1 = vi.spyOn(returnFocusTo1, "focus");
+    const focus2 = vi.spyOn(returnFocusTo2, "focus");
+
+    initFsLimitNotice(makeHost(panelEl, { returnFocusTo: returnFocusTo1 }));
+    initFsLimitNotice(makeHost(panelEl, { returnFocusTo: returnFocusTo2 }));
+    notifyFallbackSave();
+
+    panelEl.querySelector<HTMLButtonElement>("#fs-limit-notice-dismiss")!.click();
+
+    expect(focus1).toHaveBeenCalled();
+    expect(focus2).not.toHaveBeenCalled();
+  });
+
+  it("두 번째 초기화 시도는 console.warn 을 남긴다", async () => {
+    const { initFsLimitNotice } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    initFsLimitNotice(makeHost(panelEl));
+    initFsLimitNotice(makeHost(panelEl));
+
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("fsLimitNotice — 예외 격리 (NFR-2 와 동일 원칙)", () => {
+  it("querySelector 가 예외를 던져도 초기화 자체가 앱을 중단시키지 않는다", async () => {
+    const { initFsLimitNotice } = await loadFsLimitNotice();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const brokenPanelEl = {
+      querySelector: () => {
+        throw new Error("boom");
+      },
+    } as unknown as HTMLElement;
+
+    expect(() => initFsLimitNotice(makeHost(brokenPanelEl))).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("표시 도중 예외가 발생해도 앱을 중단시키지 않는다", async () => {
+    const { initFsLimitNotice, notifyFallbackSave } = await loadFsLimitNotice();
+    const panelEl = createPanel();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    initFsLimitNotice(makeHost(panelEl));
+
+    Object.defineProperty(panelEl, "hidden", {
+      set: () => {
+        throw new Error("boom");
+      },
+    });
+
+    expect(() => notifyFallbackSave()).not.toThrow();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
`Closes #25`

## 해결하는 문제

Safari 사용자가 `note.md` 를 열고 편집한 뒤 저장하면 `note (1).md` 가 다운로드 폴더에 쌓인다. **원본은 그대로다.**

File System Access API 미지원이라는 **브라우저 한계**이지 앱의 결함이 아니다. 그런데 아무 설명이 없으면 사용자는 앱이 고장났다고 판단한다.

## 판단 4건과 근거

### 1. 표시 시점 — 폴백 모드에서 **첫 저장을 시도하는 순간**, 세션당 1회

앱 진입 시가 아니다. `saveFileAs()` 의 폴백 분기가 유일한 훅 포인트이고(툴바·`Cmd+S`·`Shift+Cmd+S` 전 경로가 통과), **사용자가 실제로 그 동작을 마주친 시점**에 설명하는 것이 맥락상 가장 잘 읽힌다.

진입 시 띄우면 아직 겪지도 않은 제약을 설명하는 소음이 된다.

### 2. 중복 열기 제약은 알리지 않는다

체감 손실이 낮은데 알림을 하나 더 늘리면 **소음 대비 가치가 떨어진다.** 저장은 "내 작업이 어디 갔지" 로 이어지지만 탭 중복은 눈에 보이는 불편에 그친다.

### 3. `showNotice()` 재사용 대신 신규 요소

저장 성공 토스트와 **동시에** 떠야 한다. `notice.ts` 는 단일 슬롯 `textContent` 덮어쓰기라 하나가 다른 하나를 지운다.

DOM 순서는 `#notice` 다음, `#sw-update`·`#offline-indicator` 이전 — "지속형이 아래" 원칙 유지.

### 4. 문구는 비난조 배제

"당신 브라우저는 못 합니다" 가 아니라 **동작 방식 + 확인 위치 + 대안**을 전달한다.

**Chrome·Edge 에서는 아무것도 표시되지 않으며, E2E 가 이를 명시적으로 단언한다.**

## 설계 — 다섯 번째 주입형 리프

`src/fsLimitNotice.ts` 는 `swUpdate.ts`·`offline.ts` 와 같은 패턴이다. 전역을 직접 읽지 않고 host 로 주입받아 가짜 host 로 전량 단위 검증된다.

이 저장소에서 같은 처방을 다섯 번째 적용했고, 매번 커버리지와 테스트 용이성으로 돌아왔다.

**기존 알림 3종은 한 줄도 건드리지 않았다** — `#notice`, `#sw-update`, `#offline-indicator` 무변경. 저장 동작 자체도 무변경.

## 테스트

| 파일 | 내용 |
|------|------|
| `tests/fsLimitNotice.test.ts` (신규) | `fsLimitNotice.ts` **100%** |
| `tests/e2e/fileaccess.spec.ts` | F-58 describe 2블록 5케이스 — 폴백 표시 / 세션당 1회 / **Chrome 경로 미표시** |

### 단언 검증

구현을 **2회 되돌려** 관련 단언이 실제로 실패하는지 확인하고 원복했다. 이 세션에서 vacuous 단언을 겪은 뒤 루틴화한 절차다.

## 검증

| 항목 | 결과 |
|------|------|
| `tsc --noEmit` | 오류 0 |
| 단위 | **140건** |
| 라인 커버리지 | 60.76% → **62.32%** |
| E2E (dev 서버) | **87 통과** / 15 skip |
| `fileaccess.spec.ts` | 20/20 |
| 프리뷰 `swupdate.spec.ts` | 10/10 |

**회귀 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CtFxzJ9wgUjid5dDvZBNm