### PR TITLE
test: F-88 이후 드러난 E2E 간헐 실패 2건 수정 (#187)

### DIFF
--- a/tests/e2e/fileReload.spec.ts
+++ b/tests/e2e/fileReload.spec.ts
@@ -25,11 +25,20 @@ async function writeDisk(page: Page, name: string, content: string): Promise<voi
   );
 }
 
-async function readDisk(page: Page, name: string): Promise<string> {
+/**
+ * 트랩 #79: 쓰기는 스왑 파일을 거쳐 커밋되므로, 교체되는 찰나에 읽으면
+ * `NotFoundError` 가 난다. 던지면 `expect.poll` 이 재시도하지 못하고 즉사하므로
+ * null 로 바꿔 폴링이 다음 회차를 돌게 한다 (CI 에서 간헐 실패로 실측).
+ */
+async function readDisk(page: Page, name: string): Promise<string | null> {
   return page.evaluate(async (name) => {
-    const dir = await navigator.storage.getDirectory();
-    const handle = await dir.getFileHandle(name);
-    return (await handle.getFile()).text();
+    try {
+      const dir = await navigator.storage.getDirectory();
+      const handle = await dir.getFileHandle(name);
+      return await (await handle.getFile()).text();
+    } catch {
+      return null;
+    }
   }, name);
 }
 

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -104,7 +104,15 @@ export async function installFallbackMode(page: Page): Promise<void> {
   });
 }
 
-/** 목 상태를 갱신한다. */
+/**
+ * 목 상태를 갱신한다.
+ *
+ * `contents` 는 **병합**한다 — 통째로 갈아끼우면 이전에 연 파일의 내용이 목
+ * 디스크에서 사라지는데, 실제 디스크는 b.md 를 연다고 a.md 가 비워지지 않는다.
+ * F-88 이후 이 차이가 실제 실패로 드러났다: a.md 의 내용이 `""` 가 되면 크기가
+ * 달라져 "디스크에서 변경됨" 판정이 나고, 깨끗한 탭이라 빈 내용이 자동
+ * 반영된다 — 기준값 재기록과 경합해 **간헐적으로만** 실패했다(recent R3).
+ */
 export async function setFsMock(
   page: Page,
   patch: Partial<{
@@ -115,7 +123,11 @@ export async function setFsMock(
     failWrite: boolean;
   }>,
 ): Promise<void> {
-  await page.evaluate((p) => Object.assign(window.__fsMock!, p), patch);
+  await page.evaluate((p) => {
+    const { contents, ...rest } = p;
+    Object.assign(window.__fsMock!, rest);
+    if (contents) Object.assign(window.__fsMock!.contents, contents);
+  }, patch);
 }
 
 /** 목 디스크에 기록된 쓰기 이력을 반환한다. */


### PR DESCRIPTION
## 개요
dev → main 승격 중 릴리스 PR #191 의 CI 에서 발견된 간헐 E2E 실패 2건을 수정한다. 앱 코드 결함이 아니라 **테스트 픽스처의 디스크 모델링 결함**이 F-88(파일 변경 감지)로 드러난 것.

## 원인·수정
1. **recent R3 (CI 2회 실패·로컬 간헐 재현)** — `setFsMock()` 이 `contents` 를 통째로 교체해 b.md 를 열면 a.md 내용이 목 디스크에서 `""` 가 됐다. F-88 은 크기 변화를 '디스크 변경'으로 보고 깨끗한 탭에 빈 내용을 자동 반영 — 기준값 재기록과의 경합으로 간헐 실패. → `contents` 를 **병합**으로 변경 (실제 디스크 시맨틱).
2. **fileReload E4 (반복 실행 시 간헐)** — `readDisk()` 가 저장 커밋(스왑 파일 교체) 찰나에 `NotFoundError` 를 그대로 던져 `expect.poll` 이 즉사. → null 반환으로 바꿔 폴링이 재시도 (트랩 #79).

## 검증
- `recent.spec.ts` + `fileReload.spec.ts` --repeat-each=5: **125/125 PASS**
- 전체 E2E: 518 PASS / 15 skip · typecheck 통과